### PR TITLE
Fix #30: error on help toggle

### DIFF
--- a/autoload/mundo.py
+++ b/autoload/mundo.py
@@ -399,8 +399,12 @@ def MundoToggleHelp():
         vim.command("let g:mundo_help=1")
     else:
         vim.command("let g:mundo_help=0")
-    vim.command("call cursor(getline('.') - %d)" % (len(INLINE_HELP.split('\n')) - 2))
+    line = int(vim.eval("line('.')"))
+    column = int(vim.eval("col('.')"))
+    old_line_count = int(vim.eval("line('$')"))
     MundoRenderGraph(True)
+    new_line_count = int(vim.eval("line('$')"))
+    vim.command("call cursor(%d, %d)" % (line + new_line_count - old_line_count, column))
 
 # Mundo undo/redo
 def MundoRevert():


### PR DESCRIPTION
Here's a fix for issue #30. In Vim, `getline('.')` returns the text of the current line, not the current line number. Also, `cursor()` needs to be supplied a column number.

Tested on Vim 7.4, patch 1-1147, Python 2.7.11.