### PR TITLE
Fix inline diffs not updating after scroll (closes #34)

### DIFF
--- a/autoload/mundo.py
+++ b/autoload/mundo.py
@@ -91,7 +91,7 @@ def MundoRenderGraph(force=False):
 
     if not force and not nodesData.is_outdated() and (
                 not show_inline_undo or 
-                not (
+                (
                     mundo_first_visible_line == first_visible_line and
                     mundo_last_visible_line == last_visible_line
                 )


### PR DESCRIPTION
This fixes https://github.com/simnalamburt/vim-mundo/issues/34. The problem was introduced in https://github.com/simnalamburt/vim-mundo/commit/45d4ee7be951ba0b63386d3bd1b7254e56ce5f54.