### PR TITLE
Fix MundoMove with v:count

### DIFF
--- a/autoload/mundo.py
+++ b/autoload/mundo.py
@@ -178,7 +178,7 @@ def MundoGetTargetState():
 
 def GetNextLine(direction,move_count,write,start="line('.')"):
     start_line_no = int(vim.eval(start))
-    start_line = vim.eval("getline('.')")
+    start_line = vim.eval("getline(%d)" % start_line_no)
     mundo_verbose_graph = vim.eval('g:mundo_verbose_graph')
     if mundo_verbose_graph != "0":
         distance = 2

--- a/autoload/mundo.vim
+++ b/autoload/mundo.vim
@@ -74,15 +74,15 @@ endfunction"}}}
 "{{{ Mundo buffer settings
 
 function! s:MundoMapGraph()"{{{
-    exec 'nnoremap <script> <silent> <buffer> ' . g:mundo_map_move_older . " :call <sid>MundoPython('MundoMove(1,'. v:count .')')<CR>"
-    exec 'nnoremap <script> <silent> <buffer> ' . g:mundo_map_move_newer . " :call <sid>MundoPython('MundoMove(-1,'. v:count .')')<CR>"
+    exec 'nnoremap <script> <silent> <buffer> ' . g:mundo_map_move_older . " :<C-u>call <sid>MundoPython('MundoMove(1,'. v:count .')')<CR>"
+    exec 'nnoremap <script> <silent> <buffer> ' . g:mundo_map_move_newer . " :<C-u>call <sid>MundoPython('MundoMove(-1,'. v:count .')')<CR>"
     nnoremap <script> <silent> <buffer> <CR>          :call <sid>MundoPython('MundoRevert()')<CR>
     nnoremap <script> <silent> <buffer> o             :call <sid>MundoPython('MundoRevert()')<CR>
-    nnoremap <script> <silent> <buffer> <down>        :call <sid>MundoPython('MundoMove(1,'. v:count .')')<CR>
-    nnoremap <script> <silent> <buffer> <up>          :call <sid>MundoPython('MundoMove(-1,'. v:count .')')<CR>
-    nnoremap <script> <silent> <buffer> J             :call <sid>MundoPython('MundoMove(1,'. v:count .',True,True)')<CR>
-    nnoremap <script> <silent> <buffer> K             :call <sid>MundoPython('MundoMove(-1,'. v:count .',True,True)')<CR>
-    nnoremap <script> <silent> <buffer> gg            gg:call <sid>MundoPython('MundoMove(1,'. v:count .')')<CR>
+    nnoremap <script> <silent> <buffer> <down>        :<C-u>call <sid>MundoPython('MundoMove(1,'. v:count .')')<CR>
+    nnoremap <script> <silent> <buffer> <up>          :<C-u>call <sid>MundoPython('MundoMove(-1,'. v:count .')')<CR>
+    nnoremap <script> <silent> <buffer> J             :<C-u>call <sid>MundoPython('MundoMove(1,'. v:count .',True,True)')<CR>
+    nnoremap <script> <silent> <buffer> K             :<C-u>call <sid>MundoPython('MundoMove(-1,'. v:count .',True,True)')<CR>
+    nnoremap <script> <silent> <buffer> gg            gg:<C-u>call <sid>MundoPython('MundoMove(1,'. v:count .')')<CR>
     nnoremap <script> <silent> <buffer> P             :call <sid>MundoPython('MundoPlayTo()')<CR>
     nnoremap <script> <silent> <buffer> d             :call <sid>MundoPython('MundoRenderPatchdiff()')<CR>
     nnoremap <script> <silent> <buffer> i             :call <sid>MundoPython('MundoRenderToggleInlineDiff()')<CR>


### PR DESCRIPTION
`MundoMove` doesn't work quite right with a count. It's because the maps don't clear the command line with `<C-u>` after the `:` so the `MundoMove` command is called correctly once, but then because of the count before the command it is called more times which moves the cursor to the wrong place.