### PR TITLE
[RFC] Improved auto preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 vim-mundo
 =========
-A Vim plugin to visualizes the Vim [undo tree], a fork of [Gundo].
+A Vim plugin to visualizes the Vim [undo tree].
 
+<img src="https://simnalamburt.github.io/vim-mundo/screenshot.png">
+
+* [Official webpage]
 * [Introductory Video]
-* Website [Project Site]
 
-### How is this different than Gundo?
+<br>
+
+### How is this different than other plugins?
+Mundo is a fork of [Gundo], and it has bunch of improvements.
+
 * Several new features:
   * Ability to search undo history using <kbd>/</kbd>.
   * An 'in line' diff mode.
@@ -74,8 +80,8 @@ License, version 2] or any later version. See [COPYRIGHT] for details.
 [pull requests]: https://github.com/sjl/gundo.vim/pulls
 [undo tree]: https://neovim.io/doc/user/undo.html#undo-tree
 [Gundo]: https://github.com/sjl/gundo.vim
-[Introductory Video]: http://screenr.com/M9l
-[Project Site]: https://simnalamburt.github.io/vim-mundo
+[Official webpage]: https://simnalamburt.github.io/vim-mundo
+[Introductory Video]: https://simnalamburt.github.io/vim-mundo/screencast.mp4
 [Neovim]: https://neovim.io
 [pr-29]: https://github.com/sjl/gundo.vim/pull/29
 [pr-28]: https://github.com/sjl/gundo.vim/pull/28

--- a/autoload/airline/extensions/mundo.vim
+++ b/autoload/airline/extensions/mundo.vim
@@ -1,32 +1,35 @@
 scriptencoding utf-8
 
 function! airline#extensions#mundo#inactive_statusline(...)
-	let builder = a:1
-  if getwinvar(a:2.winnr, '&filetype') == 'Mundo'
-    return -1
-  endif
-  if getwinvar(a:2.winnr, '&filetype') == 'MundoDiff'
-		return 1
-  endif
+    let builder = a:1
+    if getwinvar(a:2.winnr, '&filetype') == 'Mundo'
+        return -1
+    endif
+    if getwinvar(a:2.winnr, '&filetype') == 'MundoDiff'
+        return 1
+    endif
 endfunction
 
 function! airline#extensions#mundo#statusline(...)
-	let builder = a:1
-  if &filetype == 'Mundo'
-    call builder.add_section('airline_a', 'Mundo')
-		call builder.split()
-    call builder.add_section('airline_z', '%p%%')
-    return 1
-  endif
-  if &filetype == 'MundoDiff'
-    call builder.add_section('airline_a', 'Mundo Diff')
-		call builder.split()
-    return 1
-  endif
+    let builder = a:1
+    if &filetype == 'Mundo'
+        call builder.add_section('airline_a',
+                    \ get(g:, 'mundo_tree_statusline', 'Mundo'))
+        call builder.split()
+        call builder.add_section('airline_z', '%p%%')
+        return 1
+    endif
+    if &filetype == 'MundoDiff'
+        call builder.add_section('airline_a',
+                    \ get(g:, 'mundo_preview_statusline', 'Mundo Diff'))
+        call builder.split()
+        return 1
+    endif
 endfunction
 
 function! airline#extensions#mundo#init(...)
-	call airline#add_statusline_func('airline#extensions#mundo#statusline')
-	call airline#add_inactive_statusline_func('airline#extensions#mundo#inactive_statusline')
+    call airline#add_statusline_func('airline#extensions#mundo#statusline')
+    call airline#add_inactive_statusline_func(
+                \ 'airline#extensions#mundo#inactive_statusline')
 endfunction
 

--- a/autoload/mundo.py
+++ b/autoload/mundo.py
@@ -262,7 +262,7 @@ def MundoMove(direction,move_count=1,relative=True,write=False):
     else:
         vim.command("call cursor(0, %d + 1)" % idx3)
 
-    if (vim.eval('g:mundo_auto_preview') == '0' or
+    if (vim.eval('g:mundo_auto_preview') != '0' and
             int(vim.eval("get(g:, 'mundo_auto_preview_delay', 0)")) <= 0):
         MundoRenderPreview()
 

--- a/autoload/mundo.py
+++ b/autoload/mundo.py
@@ -10,7 +10,6 @@
 # ============================================================================
 
 import re
-import sys
 import tempfile
 import vim
 

--- a/autoload/mundo.py
+++ b/autoload/mundo.py
@@ -18,21 +18,24 @@ from mundo.node import Nodes
 import mundo.util as util
 import mundo.graphlog as graphlog
 
-# Python Vim utility functions -----------------------------------------------------#{{{
+# Python Vim utility functions --------------------------------------------#{{{
 
 MISSING_BUFFER = "Cannot find Mundo's target buffer (%s)"
 MISSING_WINDOW = "Cannot find window (%s) for Mundo's target buffer (%s)"
 
 def _check_sanity():
-    '''Check to make sure we're not crazy.
+    """ Check to make sure we're not crazy.
 
-    Does the following things:
-
-        * Make sure the target buffer still exists.
-    '''
+        Ensures that:
+            * The target buffer exists, is loaded and is present in the tab.
+            * That neovim is not in terminal mode.
+    """
     global nodesData
+
     if not nodesData:
         nodesData = Nodes()
+
+    # Check that the target buffer exists, is loaded and is present in the tab
     b = int(vim.eval('g:mundo_target_n'))
 
     if not vim.eval('bufloaded(%d)' % int(b)):
@@ -40,8 +43,15 @@ def _check_sanity():
         return False
 
     w = int(vim.eval('bufwinnr(%d)' % int(b)))
+
     if w == -1:
         vim.command('echo "%s"' % (MISSING_WINDOW % (w, b)))
+        return False
+
+    # Check if we are in terminal mode.
+    mode = vim.eval('mode()')
+
+    if mode == 't':
         return False
 
     return True
@@ -68,9 +78,20 @@ nodesData = Nodes()
 
 # from profilehooks import profile
 # @profile(immediate=True)
-def MundoRenderGraph(force=False):
+def MundoRenderGraph(force=False):# {{{
+    """ Renders the undo graph if necessary, updating it to reflect changes in
+        the target buffer's undo tree.
+
+        Arguments
+        ---------
+        force : bool
+            If True, the graph will always be rendered. If False, then the
+            graph may not be rendered - when is already current for example.
+    """
     if not _check_sanity():
         return
+
+    util._goto_window_for_buffer('__Mundo__')
 
     first_visible_line = int(vim.eval("line('w0')"))
     last_visible_line = int(vim.eval("line('w$')"))
@@ -140,8 +161,10 @@ def MundoRenderGraph(force=False):
             pass
         i += 1
     vim.command('%d' % (i+len(header)-1))
+# }}}
 
-def MundoRenderPreview():
+def MundoRenderPreview():# {{{
+    """ Opens the preview window if necessary and renders a preview diff. """
     if not _check_sanity():
         return
 
@@ -149,12 +172,12 @@ def MundoRenderPreview():
     # Check that there's an undo state. There may not be if we're talking about
     # a buffer with no changes yet.
     if target_state is None:
-        util._goto_window_for_buffer_name('__Mundo__')
+        util._goto_window_for_buffer('__Mundo__')
         return
     else:
         target_state = int(target_state)
 
-    util._goto_window_for_buffer(vim.eval('g:mundo_target_n'))
+    util._goto_window_for_buffer(int(vim.eval('g:mundo_target_n')))
 
     nodes, nmap = nodesData.make_nodes()
 
@@ -163,19 +186,22 @@ def MundoRenderPreview():
 
     vim.command('call s:MundoOpenPreview()')
     util._output_preview_text(nodesData.preview_diff(node_before, node_after))
+# }}}
 
-    util._goto_window_for_buffer_name('__Mundo__')
-
-def MundoGetTargetState():
-    """ Get the current undo number that mundo is at.  """
-    util._goto_window_for_buffer_name('__Mundo__')
+def MundoGetTargetState():# {{{
+    """ Get the current undo number that mundo is at. """
+    util._goto_window_for_buffer('__Mundo__')
     target_line = vim.eval("getline('.')")
     matches = re.match('^.* \[([0-9]+)\] .*$',target_line)
     if matches:
         return int(matches.group(1))
     return 0
+# }}}
 
-def GetNextLine(direction,move_count,write,start="line('.')"):
+def GetNextLine(direction,move_count,write,start="line('.')"):# {{{
+    """ Recursively finds the line number resulting from undo graph traversal
+        according to the given parameters.
+    """
     start_line_no = int(vim.eval(start))
     start_line = vim.eval("getline(%d)" % start_line_no)
     mundo_verbose_graph = vim.eval('g:mundo_verbose_graph')
@@ -208,8 +234,9 @@ def GetNextLine(direction,move_count,write,start="line('.')"):
                 return next_line
             return GetNextLine(direction,1,write,str(next_line))
     return next_line
+# }}}
 
-def MundoMove(direction,move_count=1,relative=True,write=False):
+def MundoMove(direction,move_count=1,relative=True,write=False):# {{{
     """
     Move within the undo graph in the direction specified (or to the specific
     undo node specified).
@@ -261,40 +288,36 @@ def MundoMove(direction,move_count=1,relative=True,write=False):
         vim.command("call cursor(0, %d + 1)" % idx2)
     else:
         vim.command("call cursor(0, %d + 1)" % idx3)
+# }}}
 
-    if (vim.eval('g:mundo_auto_preview') != '0' and
-            int(vim.eval("get(g:, 'mundo_auto_preview_delay', 0)")) <= 0):
-        MundoRenderPreview()
-
-
-def MundoSearch():
+def MundoSearch():# {{{
     search = vim.eval("input('/')")
     vim.command('let @/="%s"' % search.replace("\\", "\\\\").replace('"', '\\"'))
     MundoNextMatch()
+# }}}
 
-
-def MundoPrevMatch():
+def MundoPrevMatch():# {{{
     MundoMatch(-1)
+# }}}
 
-
-def MundoNextMatch():
+def MundoNextMatch():# {{{
     MundoMatch(1)
+# }}}
 
-def MundoMatch(down):
+def MundoMatch(down):# {{{
     """ Jump to the next node that matches the current pattern.  If there is a
-    next node, search from the next node to the end of the list of changes. Stop
-    on a match. """
+    next node, search from the next node to the end of the list of changes.
+    Stop on a match. """
     if not _check_sanity():
         return
-
     # save the current window number (should be the navigation window)
     # then generate the undo nodes, and then go back to the current window.
-    util._goto_window_for_buffer(vim.eval('g:mundo_target_n'))
+    util._goto_window_for_buffer(int(vim.eval('g:mundo_target_n')))
 
     nodes, nmap = nodesData.make_nodes()
     total = len(nodes) - 1
 
-    util._goto_window_for_buffer_name('__Mundo__')
+    util._goto_window_for_buffer('__Mundo__')
     mundo_node = MundoGetTargetState()
 
     found_version = -1
@@ -303,7 +326,7 @@ def MundoMatch(down):
         if down < 0:
             therange = range(mundo_node+1,total+1)
         for version in therange:
-            util._goto_window_for_buffer_name('__Mundo__')
+            util._goto_window_for_buffer('__Mundo__')
             undochanges = nodesData.preview_diff(nmap[version].parent, nmap[version])
             # Look thru all of the changes, ignore the first two b/c those are the
             # diff timestamp fields (not relevent):
@@ -317,28 +340,29 @@ def MundoMatch(down):
             # found something, lets get out of here:
             if found_version != -1:
                 break
-    util._goto_window_for_buffer_name('__Mundo__')
+    util._goto_window_for_buffer('__Mundo__')
     if found_version >= 0:
         MundoMove(found_version,1,False)
+# }}}
 
-def MundoRenderPatchdiff():
+def MundoRenderPatchdiff():# {{{
     """ Call MundoRenderChangePreview and display a vert diffpatch with the
     current file. """
     if MundoRenderChangePreview():
         # if there are no lines, do nothing (show a warning).
-        util._goto_window_for_buffer_name('__Mundo_Preview__')
+        util._goto_window_for_buffer('__Mundo_Preview__')
         if vim.current.buffer[:] == ['']:
             # restore the cursor position before exiting.
-            util._goto_window_for_buffer_name('__Mundo__')
+            util._goto_window_for_buffer('__Mundo__')
             vim.command('unsilent echo "No difference between current file and undo number!"')
             return False
 
         # quit out of mundo main screen
-        util._goto_window_for_buffer_name('__Mundo__')
+        util._goto_window_for_buffer('__Mundo__')
         vim.command('quit')
 
         # save the __Mundo_Preview__ buffer to a temp file.
-        util._goto_window_for_buffer_name('__Mundo_Preview__')
+        util._goto_window_for_buffer('__Mundo_Preview__')
         (handle,filename) = tempfile.mkstemp()
         vim.command('silent! w %s' % (filename))
         # exit the __Mundo_Preview__ window
@@ -348,8 +372,9 @@ def MundoRenderPatchdiff():
         vim.command('set buftype=nofile bufhidden=delete')
         return True
     return False
+# }}}
 
-def MundoGetChangesForLine():
+def MundoGetChangesForLine():# {{{
     if not _check_sanity():
         return False
 
@@ -358,20 +383,21 @@ def MundoGetChangesForLine():
     # Check that there's an undo state. There may not be if we're talking about
     # a buffer with no changes yet.
     if target_state == None:
-        util._goto_window_for_buffer_name('__Mundo__')
+        util._goto_window_for_buffer('__Mundo__')
         return False
     else:
         target_state = int(target_state)
 
-    util._goto_window_for_buffer(vim.eval('g:mundo_target_n'))
+    util._goto_window_for_buffer(int(vim.eval('g:mundo_target_n')))
 
     nodes, nmap = nodesData.make_nodes()
 
     node_after = nmap[target_state]
     node_before = nmap[nodesData.current()]
     return nodesData.change_preview_diff(node_before, node_after)
+# }}}
 
-def MundoRenderChangePreview():
+def MundoRenderChangePreview():# {{{
     """ Render the selected undo level with the current file.
     Return True on success, False on failure. """
     if not _check_sanity():
@@ -380,11 +406,13 @@ def MundoRenderChangePreview():
     vim.command('call s:MundoOpenPreview()')
     util._output_preview_text(MundoGetChangesForLine())
 
-    util._goto_window_for_buffer_name('__Mundo__')
+    util._goto_window_for_buffer('__Mundo__')
 
     return True
+# }}}
 
-def MundoRenderToggleInlineDiff():
+def MundoRenderToggleInlineDiff():# {{{
+    """ Toggles g:mundo_inline_undo and redraws the graph window. """
     show_inline = int(vim.eval('g:mundo_inline_undo'))
     if show_inline == 0:
         vim.command("let g:mundo_inline_undo=1")
@@ -394,8 +422,10 @@ def MundoRenderToggleInlineDiff():
     nodesData.clear_oneline_diffs()
     MundoRenderGraph(True)
     vim.command("call cursor(%d,0)" % line)
+# }}}
 
-def MundoToggleHelp():
+def MundoToggleHelp():# {{{
+    """ Toggles g:mundo_help and redraws the graph window. """
     show_help = int(vim.eval('g:mundo_help'))
     if show_help == 0:
         vim.command("let g:mundo_help=1")
@@ -406,15 +436,22 @@ def MundoToggleHelp():
     old_line_count = int(vim.eval("line('$')"))
     MundoRenderGraph(True)
     new_line_count = int(vim.eval("line('$')"))
-    vim.command("call cursor(%d, %d)" % (line + new_line_count - old_line_count, column))
+    vim.command(
+        "call cursor(%d, %d)" % (line + new_line_count - old_line_count,
+                                 column)
+    )
 
-# Mundo undo/redo
-def MundoRevert():
+# Mundo undo/redo}}}
+
+def MundoRevert():# {{{
+    """ Reverts the target buffer to the state associated with a selected node
+        in the undo graph.
+    """
     if not _check_sanity():
         return
 
     target_n = MundoGetTargetState()
-    back = vim.eval('g:mundo_target_n')
+    back = int(vim.eval('g:mundo_target_n'))
 
     util._goto_window_for_buffer(back)
     util._undo_to(target_n)
@@ -425,8 +462,12 @@ def MundoRevert():
 
     if int(vim.eval('g:mundo_close_on_revert')):
         vim.command('MundoToggle')
+# }}}
 
-def MundoPlayTo():
+def MundoPlayTo():# {{{
+    """ Replays changes between the current state and a selected state in
+        real-time.
+    """
     if not _check_sanity():
         return
 
@@ -443,8 +484,7 @@ def MundoPlayTo():
 
     start = nmap[nodesData.current()]
     end = nmap[target_n]
-
-    def _walk_branch(origin, dest):
+    def _walk_branch(origin, dest):# {{{
         rev = origin.n < dest.n
 
         nodes = []
@@ -466,6 +506,7 @@ def MundoPlayTo():
             return reversed(nodes)
         else:
             return nodes
+    # }}}
 
     branch = _walk_branch(start, end)
 
@@ -480,3 +521,6 @@ def MundoPlayTo():
         util._goto_window_for_buffer(back)
         vim.command('redraw')
         vim.command('sleep %dm' % delay)
+# }}}
+
+#  vim: set ts=4 sw=4 tw=79 fdm=marker et :

--- a/autoload/mundo.py
+++ b/autoload/mundo.py
@@ -185,6 +185,9 @@ def MundoRenderPreview():# {{{
 
     vim.command('call s:MundoOpenPreview()')
     util._output_preview_text(nodesData.preview_diff(node_before, node_after))
+
+    # Mark the preview as up-to-date
+    vim.command('call mundo#MundoAutoPreviewUpdate(0)')
 # }}}
 
 def MundoGetTargetState():# {{{
@@ -287,6 +290,9 @@ def MundoMove(direction,move_count=1,relative=True,write=False):# {{{
         vim.command("call cursor(0, %d + 1)" % idx2)
     else:
         vim.command("call cursor(0, %d + 1)" % idx3)
+
+    # Mark the preview as outdated
+    vim.command('call mundo#MundoAutoPreviewUpdate(1)')
 # }}}
 
 def MundoSearch():# {{{
@@ -405,8 +411,10 @@ def MundoRenderChangePreview():# {{{
 
     vim.command('call s:MundoOpenPreview()')
     util._output_preview_text(MundoGetChangesForLine())
-
     util._goto_window_for_buffer('__Mundo__')
+
+    # Mark the preview as up-to-date
+    vim.command('call mundo#MundoAutoPreviewUpdate(0)')
 
     return True
 # }}}
@@ -456,7 +464,8 @@ def MundoRevert():# {{{
     util._goto_window_for_buffer(back)
     util._undo_to(target_n)
 
-    vim.command('MundoRenderGraph')
+    MundoRenderGraph()
+
     if int(vim.eval('g:mundo_return_on_revert')):
         util._goto_window_for_buffer(back)
 
@@ -516,11 +525,10 @@ def MundoPlayTo():# {{{
 
     for node in branch:
         util._undo_to(node.n)
-        vim.command('MundoRenderGraph')
+        MundoRenderGraph()
         util.normal('zz')
         util._goto_window_for_buffer(back)
-        vim.command('redraw')
-        vim.command('sleep %dm' % delay)
+        vim.command('redraw | sleep %dm' % delay)
 # }}}
 
 #  vim: set ts=4 sw=4 tw=79 fdm=marker et :

--- a/autoload/mundo.py
+++ b/autoload/mundo.py
@@ -90,7 +90,7 @@ def MundoRenderGraph(force=False):
     mundo_first_visible_line = int(vim.eval("g:mundo_first_visible_line"))
 
     if not force and not nodesData.is_outdated() and (
-                not show_inline_undo or 
+                not show_inline_undo or
                 (
                     mundo_first_visible_line == first_visible_line and
                     mundo_last_visible_line == last_visible_line
@@ -262,7 +262,8 @@ def MundoMove(direction,move_count=1,relative=True,write=False):
     else:
         vim.command("call cursor(0, %d + 1)" % idx3)
 
-    if vim.eval('g:mundo_auto_preview') == '1':
+    if (vim.eval('g:mundo_auto_preview') == '1' and
+            vim.eval("get(g:, 'mundo_auto_preview_delay', 0)") == 0):
         MundoRenderPreview()
 
 

--- a/autoload/mundo.py
+++ b/autoload/mundo.py
@@ -262,8 +262,8 @@ def MundoMove(direction,move_count=1,relative=True,write=False):
     else:
         vim.command("call cursor(0, %d + 1)" % idx3)
 
-    if (vim.eval('g:mundo_auto_preview') == '1' and
-            vim.eval("get(g:, 'mundo_auto_preview_delay', 0)") == 0):
+    if (vim.eval('g:mundo_auto_preview') != '0' and
+            int(vim.eval("get(g:, 'mundo_auto_preview_delay', 0)")) <= 0):
         MundoRenderPreview()
 
 

--- a/autoload/mundo.py
+++ b/autoload/mundo.py
@@ -262,7 +262,7 @@ def MundoMove(direction,move_count=1,relative=True,write=False):
     else:
         vim.command("call cursor(0, %d + 1)" % idx3)
 
-    if (vim.eval('g:mundo_auto_preview') != '0' or
+    if (vim.eval('g:mundo_auto_preview') == '0' or
             int(vim.eval("get(g:, 'mundo_auto_preview_delay', 0)")) <= 0):
         MundoRenderPreview()
 

--- a/autoload/mundo.py
+++ b/autoload/mundo.py
@@ -168,18 +168,17 @@ def MundoRenderPreview():# {{{
         return
 
     target_state = MundoGetTargetState()
-    # Check that there's an undo state. There may not be if we're talking about
-    # a buffer with no changes yet.
-    if target_state is None:
-        util._goto_window_for_buffer('__Mundo__')
+    target_n = int(vim.eval('g:mundo_target_n'))
+
+    # If there's no target state or the buffer has changed, update the cached
+    # undo tree data, redraw the graph and abort preview rendering
+    if target_state is None or nodesData.target_n != target_n:
+        nodesData.make_nodes()
+        MundoRenderGraph(True)
         return
-    else:
-        target_state = int(target_state)
 
-    util._goto_window_for_buffer(int(vim.eval('g:mundo_target_n')))
-
+    util._goto_window_for_buffer(target_n)
     nodes, nmap = nodesData.make_nodes()
-
     node_after = nmap[target_state]
     node_before = node_after.parent
 

--- a/autoload/mundo.py
+++ b/autoload/mundo.py
@@ -397,8 +397,9 @@ def MundoGetChangesForLine():# {{{
 # }}}
 
 def MundoRenderChangePreview():# {{{
-    """ Render the selected undo level with the current file.
-    Return True on success, False on failure. """
+    """ Render a diff of the target buffer and the selected undo
+        tree node. Returns True on success, False otherwise.
+    """
     if not _check_sanity():
         return
 

--- a/autoload/mundo.py
+++ b/autoload/mundo.py
@@ -262,7 +262,7 @@ def MundoMove(direction,move_count=1,relative=True,write=False):
     else:
         vim.command("call cursor(0, %d + 1)" % idx3)
 
-    if (vim.eval('g:mundo_auto_preview') != '0' and
+    if (vim.eval('g:mundo_auto_preview') != '0' or
             int(vim.eval("get(g:, 'mundo_auto_preview_delay', 0)")) <= 0):
         MundoRenderPreview()
 

--- a/autoload/mundo.vim
+++ b/autoload/mundo.vim
@@ -270,8 +270,8 @@ function! s:MundoValidateBuffer()"{{{
         let reason = 'is not modifiable'
     elseif &previewwindow
         let reason = 'is a preview window'
-    elseif &buftype != '' && &buftype != 'acwrite'
-        let reason = 'has invalid buffer type "'.&buftype.'"'
+    elseif &buftype == 'help' || &buftype == 'quickfix' || &buftype == 'terminal'
+        let reason = 'is a '.&buftype.' window'
     else
         return 1
     endif

--- a/autoload/mundo.vim
+++ b/autoload/mundo.vim
@@ -43,6 +43,7 @@ endif"}}}
 
 let s:plugin_path = escape(expand('<sfile>:p:h'), '\')
 let s:auto_preview_timer = -1
+let s:auto_preview_line = -1
 "}}}
 
 "{{{ Mundo utility functions

--- a/autoload/mundo.vim
+++ b/autoload/mundo.vim
@@ -91,8 +91,6 @@ function! s:MundoMapGraph()"{{{
                 \ " :<C-u>call <sid>MundoPython('MundoMove(-1,'. v:count .')')<CR>"
     nnoremap <script> <silent> <buffer> <CR>          :<C-u>call <sid>MundoRenderPreview(1)<CR>:<C-u> call <sid>MundoPythonRestoreView('MundoRevert()')<CR>
     nnoremap <script> <silent> <buffer> o             :<C-u>call <sid>MundoRenderPreview(1)<CR>:<C-u> call <sid>MundoPythonRestoreView('MundoRevert()')<CR>
-    nnoremap <script> <silent> <buffer> <down>        :<C-u>call <sid>MundoPython('MundoMove(1,'.v:count.')')<CR>
-    nnoremap <script> <silent> <buffer> <up>          :<C-u>call <sid>MundoPython('MundoMove(-1,'.v:count.')')<CR>
     if g:mundo_map_up_down
         nnoremap <script> <silent> <buffer> <down>        :<C-u>call <sid>MundoPython('MundoMove(1,'.v:count.')')<CR>
         nnoremap <script> <silent> <buffer> <up>          :<C-u>call <sid>MundoPython('MundoMove(-1,'.v:count.')')<CR>

--- a/autoload/mundo.vim
+++ b/autoload/mundo.vim
@@ -411,12 +411,16 @@ function! s:MundoRefresh()"{{{
 endfunction"}}}
 
 function! s:MundoUpdateCursor()"{{{
-    if !get(g:, 'mundo_auto_preview_delay_refresh', 0)
+    if !g:mundo_auto_preview
+        return s:MundoRefresh()
+    endif
+
+    if !get(g:, 'mundo_inline_undo_delay', 0)
         call s:MundoRefresh()
     endif
 
-    if !g:mundo_auto_preview || !get(g:, 'mundo_auto_preview_delay', 0)
-        return
+    if get(g:, 'mundo_auto_preview_delay', 0) <= 0
+        return s:MundoPython('MundoRenderPreview()')
     endif
 
     call s:MundoRestartCursorTimer()
@@ -437,14 +441,19 @@ function! s:MundoStopCursorTimer()"{{{
 endfunction"}}}
 
 function! s:MundoRenderPreviewDelayed(...)"{{{
+    if s:auto_preview_line == line('.')
+        return
+    endif
+
     if mode() != 'n'
         return s:MundoRestartCursorTimer()
     endif
 
-    if get(g:, 'mundo_auto_preview_delay_refresh', 0)
+    if get(g:, 'mundo_inline_undo_delay', 0)
         call s:MundoRefresh()
     endif
 
+    let s:auto_preview_line = line('.')
     call s:MundoPython('MundoRenderPreview()')
 endfunction"}}}
 

--- a/autoload/mundo.vim
+++ b/autoload/mundo.vim
@@ -60,12 +60,15 @@ endfunction"}}}
 " an integer buffer number or a string file-pattern; for a detailed description
 " see :h bufname. Returns 1 if successful, 0 otherwise.
 function! s:MundoGoToWindowForBuffer(expr)"{{{
-    if bufwinnr(bufnr(a:expr)) != -1
-        exe bufwinnr(bufnr(a:expr)) . "wincmd w"
-        return 1
+    let l:winnr = bufwinnr(bufnr(a:expr))
+
+    if l:winnr == -1
+        return 0
+    elseif l:winnr != winnr()
+        exe l:winnr . "wincmd w"
     endif
 
-    return 0
+    return 1
 endfunction"}}}
 
 " Similar to MundoGoToWindowForBuffer, but considers windows in all tabs.
@@ -319,7 +322,7 @@ function! s:MundoOpen() abort "{{{
     " Validate and target buffer, store buffer number & file
     let is_valid_reason = s:MundoIsValidBuffer()
 
-    if ! is_valid_reason
+    if !is_valid_reason
         echom 'Current buffer ('.bufnr('').') is not a valid target for Mundo'.
                     \ ' (Reason: '.is_valid_reason.')'
         return
@@ -366,20 +369,18 @@ function! s:MundoOpen() abort "{{{
     let &splitbelow = 0
 
     call s:MundoOpenPreview()
-"    exe bufwinnr(g:mundo_target_n) . "wincmd w"
     call s:MundoGoToWindowForBuffer(g:mundo_target_n)
     call s:MundoOpenGraph()
-
     call mundo#MundoRenderGraph()
 
-    " Move cursor to the graph if the window was created
+    " If necessary, move the graph window cursor to the first node
     if line('.') == 1
         call s:MundoPython('MundoMove(1, 1)')
     endif
 
     call mundo#MundoRenderPreview()
 
-    " Restore `splitbelow` value.
+    " Restore `splitbelow`
     let &splitbelow = saved_splitbelow
 endfunction"}}}
 

--- a/autoload/mundo.vim
+++ b/autoload/mundo.vim
@@ -9,21 +9,51 @@
 " ============================================================================
 
 
-"{{{ Init
 let s:save_cpo = &cpo
 set cpo&vim
+
+"{{{ Init
+
+" Initialise global vars
+let s:auto_preview_timer = -1"{{{
+let s:auto_preview_line = -1
+let s:exec_python = 0
+let s:has_supported_python = 0
+let s:has_timers = 1
+let s:init_error = 'Initialisation failed due to an unknown error. '
+            \ . 'Please submit a bug report :)'
+
+" This has to be outside of a function, otherwise it just picks up the CWD
+let s:plugin_path = escape(expand('<sfile>:p:h'), '\')"}}}
+
+" Default to placeholder functions for exposed methods
+function! mundo#MundoToggle()"{{{
+    call mundo#util#Message("WarningMsg",
+                \ 'Initialisation error: ' . s:init_error)
+endfunction
+function! mundo#MundoShow()
+    call mundo#util#Message("WarningMsg",
+                \ 'Initialisation error: ' . s:init_error)
+endfunction
+function! mundo#MundoHide()
+    call mundo#util#Message("WarningMsg"
+                \ 'Initialisation error: ' . s:init_error)
+endfunction
+function! mundo#MundoRenderGraph()
+    call mundo#util#Message("WarningMsg"
+                \ 'Initialisation error: ' . s:init_error)
+endfunction"}}}
+
+" Check vim version
 if v:version < '703'"{{{
-    function! s:MundoDidNotLoad()
-        echohl WarningMsg|echomsg "Mundo unavailable: requires Vim 7.3+"|echohl None
-    endfunction
-    command! -nargs=0 MundoToggle call s:MundoDidNotLoad()
+    let s:init_error = 'Vim version 7.03+ or later is required.'
+    let &cpo = s:save_cpo
     finish
+elseif v:version < '800' || !has('timers')
+    let s:has_timers = 0
 endif"}}}
 
-call mundo#util#init()
-
-
-let s:has_supported_python = 0
+" Check python version
 if g:mundo_prefer_python3 && has('python3')"{{{
     let s:has_supported_python = 2
 elseif has('python')"
@@ -33,74 +63,27 @@ elseif has('python3')"
 endif
 
 if !s:has_supported_python
-    function! s:MundoDidNotLoad()
-        echohl WarningMsg|echomsg "Mundo requires Vim to be compiled with Python 2.4+"|echohl None
-    endfunction
-    command! -nargs=0 MundoToggle call s:MundoDidNotLoad()
+    let s:init_error = 'A supported python version was not found.'
+    let &cpo = s:save_cpo
     finish
 endif"}}}
 
-
-let s:plugin_path = escape(expand('<sfile>:p:h'), '\')
-let s:auto_preview_timer = -1
-let s:auto_preview_line = -1
-"}}}
-
-"{{{ Mundo utility functions
+" Python init methods
+function! s:InitPythonModule(python)"{{{
+    exe a:python .' import sys'
+    exe a:python .' if sys.version_info[:2] < (2, 4): '.
+                \ 'vim.command("let s:has_supported_python = 0")'
+endfunction"}}}
 
 function! s:MundoSetupPythonPath()"{{{
     if g:mundo_python_path_setup == 0
         let g:mundo_python_path_setup = 1
-        call s:MundoPython('sys.path.insert(1, "'. s:mundo_path .'")')
-        call s:MundoPython('sys.path.insert(1, "'. s:mundo_path .'/mundo")')
+        call s:MundoPython('sys.path.insert(1, "'. s:plugin_path .'")')
+        call s:MundoPython('sys.path.insert(1, "'. s:plugin_path .'/mundo")')
     end
 endfunction"}}}
 
-" Moves to the first window in the current tab corresponding to expr. Accepts
-" an integer buffer number or a string file-pattern; for a detailed description
-" see :h bufname. Returns 1 if successful, 0 otherwise.
-function! s:MundoGoToWindowForBuffer(expr)"{{{
-    let l:winnr = bufwinnr(bufnr(a:expr))
-
-    if l:winnr == -1
-        return 0
-    elseif l:winnr != winnr()
-        exe l:winnr . "wincmd w"
-    endif
-
-    return 1
-endfunction"}}}
-
-" Similar to MundoGoToWindowForBuffer, but considers windows in all tabs.
-" Prioritises matches in the current tab.
-function! s:MundoGoToWindowForBufferGlobal(expr)"{{{
-    if s:MundoGoToWindowForBuffer(a:expr)
-        return 1
-    endif
-
-    let l:bufWinIDs = win_findbuf(bufnr(a:expr))
-
-    if len(l:bufWinIDs) <= 0
-        return 0
-    endif
-
-    call win_gotoid(l:bufWinIDs[0])
-    return 1
-endfunction"}}}
-
-" Returns True if the graph or preview windows are open in the current tab.
-function! s:MundoIsVisible()"{{{
-    return bufwinnr(bufnr("__Mundo__")) != -1 ||
-                \ bufwinnr(bufnr("__Mundo_Preview__")) != -1
-endfunction"}}}
-
-function! s:MundoInlineHelpLength()"{{{
-    if g:mundo_help
-        return 10
-    else
-        return 0
-    endif
-endfunction"}}}}}
+"}}}
 
 "{{{ Mundo buffer settings
 
@@ -115,13 +98,13 @@ function! s:MundoMapGraph()"{{{
     nnoremap <script> <silent> <buffer> K             :<C-u>call <sid>MundoPython('MundoMove(-1,'. v:count .',True,True)')<CR>
     nnoremap <script> <silent> <buffer> gg            gg:<C-u>call <sid>MundoPython('MundoMove(1,'. v:count .')')<CR>
     nnoremap <script> <silent> <buffer> P             :call <sid>MundoPython('MundoPlayTo()')<CR>
-    nnoremap <script> <silent> <buffer> d             :call <sid>MundoPython('MundoRenderPatchdiff()')<CR>
-    nnoremap <script> <silent> <buffer> i             :call <sid>MundoPython('MundoRenderToggleInlineDiff()')<CR>
+    nnoremap <script> <silent> <buffer> d             :call <sid>MundoPythonRestoreView('MundoRenderPatchdiff()')<CR>
+    nnoremap <script> <silent> <buffer> i             :call <sid>MundoPythonRestoreView('MundoRenderToggleInlineDiff()')<CR>
     nnoremap <script> <silent> <buffer> /             :call <sid>MundoPython('MundoSearch()')<CR>
     nnoremap <script> <silent> <buffer> n             :call <sid>MundoPython('MundoNextMatch()')<CR>
     nnoremap <script> <silent> <buffer> N             :call <sid>MundoPython('MundoPrevMatch()')<CR>
-    nnoremap <script> <silent> <buffer> p             :call <sid>MundoPython('MundoRenderChangePreview()')<CR>
-    nnoremap <script> <silent> <buffer> r             :call <sid>MundoPython('MundoRenderPreview()')<CR>
+    nnoremap <script> <silent> <buffer> p             :call <sid>MundoPythonRestoreView('MundoRenderChangePreview()')<CR>
+    nnoremap <script> <silent> <buffer> r             :call <sid>MundoPythonRestoreView('MundoRenderPreview()')<CR>:call mundo#util#MundoGoToWindowForBuffer('__Mundo__')<CR>
     nnoremap <script> <silent> <buffer> ?             :call <sid>MundoPython('MundoToggleHelp()')<CR>
     nnoremap <script> <silent> <buffer> q             :call <sid>MundoClose()<CR>
     cabbrev  <script> <silent> <buffer> q             call <sid>MundoClose()
@@ -190,88 +173,55 @@ endfunction"}}}
 "{{{ Mundo buffer/window management
 
 function! s:MundoResizeBuffers(backto)"{{{
-    call s:MundoGoToWindowForBuffer('__Mundo__')
+    call mundo#util#MundoGoToWindowForBuffer('__Mundo__')
     exe "vertical resize " . g:mundo_width
 
-    call s:MundoGoToWindowForBuffer('__Mundo_Preview__')
+    call mundo#util#MundoGoToWindowForBuffer('__Mundo_Preview__')
     exe "resize " . g:mundo_preview_height
 
     exe a:backto . "wincmd w"
 endfunction"}}}
 
+" Open or create the graph window. Assumes that the preview window is open.
 function! s:MundoOpenGraph()"{{{
-    let existing_mundo_buffer = bufnr("__Mundo__")
 
-    if existing_mundo_buffer == -1
-        call assert_true(s:MundoGoToWindowForBuffer('__Mundo_Preview__'))
-        exe "new __Mundo__"
-        set fdm=manual
-        if g:mundo_preview_bottom
-            if g:mundo_right
-                wincmd L
-            else
-                wincmd H
-            endif
-        endif
-        call s:MundoResizeBuffers(winnr())
-    else
-        let existing_mundo_window = bufwinnr(existing_mundo_buffer)
+    if !mundo#util#MundoGoToWindowForBuffer("__Mundo__")
+        call assert_true(mundo#util#MundoGoToWindowForBuffer(
+                    \ '__Mundo_Preview__'))
+        let existing_mundo_buffer = bufnr("__Mundo__")
 
-        if existing_mundo_window != -1
-            if winnr() != existing_mundo_window
-                exe existing_mundo_window . "wincmd w"
-            endif
+        if existing_mundo_buffer == -1
+            execute 'new __Mundo__ | set fdm=manual | '
+                        \ .'wincmd '
+                        \ .(g:mundo_preview_bottom && g:mundo_right ? 'L':'H')
         else
-            call s:MundoGoToWindowForBuffer('__Mundo_Preview__')
-            if g:mundo_preview_bottom
-                if g:mundo_right
-                    exe "botright vsplit +buffer" . existing_mundo_buffer
-                else
-                    exe "topleft vsplit +buffer" . existing_mundo_buffer
-                endif
-            else
-                exe "split +buffer" . existing_mundo_buffer
-            endif
-            call s:MundoResizeBuffers(winnr())
+            execute (g:mundo_preview_bottom ?
+                        \ (g:mundo_right ? 'botright ' : 'topleft ').'v' : '')
+                        \ .'split +buffer' . existing_mundo_buffer
         endif
+
+        call s:MundoResizeBuffers(winnr())
     endif
+
     if exists("g:mundo_tree_statusline")
         let &l:statusline = g:mundo_tree_statusline
     endif
 endfunction"}}}
 
+" Open or create the preview window.
 function! s:MundoOpenPreview()"{{{
-    let existing_preview_buffer = bufnr("__Mundo_Preview__")
+    if !mundo#util#MundoGoToWindowForBuffer("__Mundo_Preview__")
+        let existing_preview_buffer = bufnr("__Mundo_Preview__")
+        let pos = g:mundo_preview_bottom || g:mundo_right ? 'botright' :
+                    \ 'topleft'
+        let vert = g:mundo_preview_bottom ? '' : 'v'
+        let buf = vert.(existing_preview_buffer == -1 ?
+                    \ 'new __Mundo_Preview__' :
+                    \ 'split +buffer' . existing_preview_buffer)
 
-    if existing_preview_buffer == -1
-        if g:mundo_preview_bottom
-            exe "botright keepalt new __Mundo_Preview__"
-        else
-            if g:mundo_right
-                exe "botright keepalt vnew __Mundo_Preview__"
-            else
-                exe "topleft keepalt vnew __Mundo_Preview__"
-            endif
-        endif
-    else
-        let existing_preview_window = bufwinnr(existing_preview_buffer)
-
-        if existing_preview_window != -1
-            if winnr() != existing_preview_window
-                exe existing_preview_window . "wincmd w"
-            endif
-        else
-            if g:mundo_preview_bottom
-                exe "botright keepalt split +buffer" . existing_preview_buffer
-            else
-                if g:mundo_right
-                    exe "botright keepalt vsplit +buffer" . existing_preview_buffer
-                else
-                    exe "topleft keepalt vsplit +buffer" . existing_preview_buffer
-                endif
-            endif
-        endif
+        execute pos.' keepalt '.buf
     endif
+
     if exists("g:mundo_preview_statusline")
         let &l:statusline = g:mundo_preview_statusline
     endif
@@ -281,11 +231,8 @@ endfunction"}}}
 function! s:MundoClose() abort "{{{
     let [l:tabid, l:winid] = win_id2tabwin(win_getid())
 
-    while s:MundoGoToWindowForBufferGlobal('__Mundo__')
-        quit
-    endwhile
-
-    while s:MundoGoToWindowForBufferGlobal('__Mundo_Preview__')
+    while mundo#util#MundoGoToWindowForBufferGlobal('__Mundo__') ||
+                \ mundo#util#MundoGoToWindowForBufferGlobal('__Mundo_Preview__')
         quit
     endwhile
 
@@ -295,26 +242,37 @@ function! s:MundoClose() abort "{{{
         execute 'normal! ' . l:tabid . 'gt'
     endif
 
-    call s:MundoGoToWindowForBuffer(get(g:, 'mundo_target_n', -1))
-endfunction"}}}
-
-function! s:InitPythonModule(python)"{{{
-    exe a:python .' import sys'
-    exe a:python .' if sys.version_info[:2] < (2, 4): '.
-                \ 'vim.command("let s:has_supported_python = 0")'
+    call mundo#util#MundoGoToWindowForBuffer(get(g:, 'mundo_target_n', -1))
 endfunction"}}}
 
 " Returns 1 if the current buffer is a valid target buffer for Mundo, or a
 " (falsy) string indicating the reason if otherwise.
 function! s:MundoIsValidBuffer()"{{{
-    if !&modifiable | return 'is not modifiable' | endif
-    if &previewwindow | return 'is preview window' | endif
-    if &buftype != '' && &buftype != 'acwrite' |
-                \ return 'invalid buffer type "'.&buftype.'"' | endif
+    if !&modifiable
+        return 'is not modifiable'
+    elseif &previewwindow
+        return 'is a preview window'
+    elseif &buftype != '' && &buftype != 'acwrite'
+        return 'has invalid buffer type "'.&buftype.'"'
+    endif
+
     return 1
 endfunction "}}}
 
-" }}}
+" Returns True if the graph or preview windows are open in the current tab.
+function! s:MundoIsVisible()"{{{
+    return bufwinnr(bufnr("__Mundo__")) != -1 ||
+                \ bufwinnr(bufnr("__Mundo_Preview__")) != -1
+endfunction"}}}
+
+" Returns the current length of the inline help text
+function! s:MundoInlineHelpLength()"{{{
+    if g:mundo_help
+        return 10
+    else
+        return 0
+    endif
+endfunction"}}}
 
 " Open/reopen Mundo for the current buffer, initialising the python module if
 " necessary.
@@ -323,8 +281,9 @@ function! s:MundoOpen() abort "{{{
     let is_valid_reason = s:MundoIsValidBuffer()
 
     if !is_valid_reason
-        echom 'Current buffer ('.bufnr('').') is not a valid target for Mundo'.
-                    \ ' (Reason: '.is_valid_reason.')'
+        mundo#util#Message('None',
+                    \ 'Current buffer ('.bufnr('').') is not a valid target '
+                    \ .'for Mundo (Reason: '.is_valid_reason.')'
         return
     endif
 
@@ -348,17 +307,17 @@ function! s:MundoOpen() abort "{{{
             call s:InitPythonModule('python')
         endif
 
-        if !s:has_supported_python
-            function! s:MundoDidNotLoad()
-                echohl WarningMsg
-                echomsg "Mundo unavailable: requires Vim 7.3+"
-                echohl None
-            endfunction
-
-            command! -nargs=0 MundoToggle call s:MundoDidNotLoad()
-            call s:MundoDidNotLoad()
-            return
-        endif
+        " Won't ever get here if python hasn't loaded
+"        if !s:has_supported_python
+"            function! s:MundoDidNotLoad()
+"                call mundo#util#Message('WarningMsg',
+"                            \ "Mundo unavailable: requires Vim 7.3+")
+"            endfunction
+"
+"            command! -nargs=0 MundoToggle call s:MundoDidNotLoad()
+"            call s:MundoDidNotLoad()
+"            return
+"        endif
 
         let g:mundo_py_loaded = 1
     endif
@@ -369,23 +328,20 @@ function! s:MundoOpen() abort "{{{
     let &splitbelow = 0
 
     call s:MundoOpenPreview()
-    call s:MundoGoToWindowForBuffer(g:mundo_target_n)
+    call mundo#util#MundoGoToWindowForBuffer(g:mundo_target_n)
     call s:MundoOpenGraph()
     call mundo#MundoRenderGraph()
 
     " If necessary, move the graph window cursor to the first node
-    if line('.') == 1
+    if line('.') <= s:MundoInlineHelpLength() + 1
         call s:MundoPython('MundoMove(1, 1)')
     endif
 
-    call mundo#MundoRenderPreview()
+    call s:MundoRenderPreview()
 
     " Restore `splitbelow`
     let &splitbelow = saved_splitbelow
 endfunction"}}}
-
-" This has to be outside of a function otherwise it just picks up the CWD
-let s:mundo_path = escape( expand( '<sfile>:p:h' ), '\' )
 
 function! s:MundoToggle()"{{{
     if s:MundoIsVisible()
@@ -437,44 +393,25 @@ endfunction"}}}
 " Wrapper for MundoPython() that restores the window state and prevents other
 " Mundo autocommands (with the exception of BufNewFile) from triggering.
 function! s:MundoPythonRestoreView(fn)"{{{
-    " Save current window and view information, ignore autocommands
+    " Save current window and view
     let currentWin  = winnr()
     let winView = winsaveview()
-    let eventignorePrev = &eventignore
-    set eventignore=CursorHold,CursorMoved,TextChanged,InsertLeave,BufLeave,
-                \BufEnter
 
-    call s:MundoPython(a:fn)
+    " Eventignore does not seem to work here..?
+    let s:exec_python = 1 | call s:MundoPython(a:fn) | let s:exec_python = 0
 
-    " Restore ignored autocommands, window and view information
-    silent exec 'set eventignore='.eventignorePrev
+    " Restore window / view
     execute currentWin .'wincmd w'
     call winrestview(winView)
 endfunction"}}}
 
-function! mundo#MundoRenderGraph()"{{{
-    call s:MundoPythonRestoreView('MundoRenderGraph()')
-endfunction"}}}
-
-function! mundo#MundoRenderPreview()"{{{
+function! s:MundoRenderPreview()"{{{
     call s:MundoPythonRestoreView('MundoRenderPreview()')
 endfunction"}}}
 
 "}}}
 
 "{{{ Misc
-
-function! mundo#MundoToggle()"{{{
-    call s:MundoToggle()
-endfunction"}}}
-
-function! mundo#MundoShow()"{{{
-    call s:MundoShow()
-endfunction"}}}
-
-function! mundo#MundoHide()"{{{
-    call s:MundoHide()
-endfunction"}}}
 
 " automatically reload Mundo buffer if open
 function! s:MundoRefresh()"{{{
@@ -487,13 +424,22 @@ function! s:MundoRefresh()"{{{
         return
     endif
 
+    " Disable the automatic preview delay if vim lacks support for timers
+    if get(g:, 'mundo_auto_preview_delay', 0) > 0 && !s:has_timers
+        let g:mundo_auto_preview_delay = 0
+        call mundo#util#Message('WarningMsg',
+                    \ 'The "g:mundo_auto_preview_delay" option requires'
+                    \ .' support for timers. Please upgrade to either vim 8.0+'
+                    \ .' (with +timers) or neovim to use this feature.')
+    endif
+
     " Handle normal refresh
     if get(g:, 'mundo_auto_preview_delay', 0) <= 0
         call mundo#MundoRenderGraph()
 
         if get(g:, 'mundo_auto_preview', 0) && (currentWin == mundoWin)
                     \ && mode() == 'n'
-            call mundo#MundoRenderPreview()
+            call s:MundoRenderPreview()
         endif
         return
     endif
@@ -529,12 +475,11 @@ function! s:MundoRefreshDelayed(...)"{{{
 
     call mundo#MundoRenderGraph()
 
-    " Handle other windows
-    if currentWin != mundoWin
+    if currentWin != mundoWin || !get(g:, 'mundo_auto_preview', 0)
+                \ || currentWin != mundoWin
         return
     endif
 
-    " Handle graph window (__Mundo__)
     if s:auto_preview_line == line('.')
         return
     endif
@@ -545,7 +490,7 @@ function! s:MundoRefreshDelayed(...)"{{{
     endif
 
     let s:auto_preview_line = line('.')
-    call mundo#MundoRenderPreview()
+    call s:MundoRenderPreview()
 endfunction"}}}
 
 augroup MundoAug"{{{
@@ -553,13 +498,34 @@ augroup MundoAug"{{{
     autocmd BufNewFile __Mundo__ call s:MundoSettingsGraph()
     autocmd BufNewFile __Mundo_Preview__ call s:MundoSettingsPreview()
     autocmd CursorHold,CursorMoved,TextChanged,InsertLeave *
-                \ call s:MundoRefresh()
-    autocmd BufLeave __Mundo__ call s:MundoStopRefreshTimer()
-    autocmd BufEnter __Mundo__ let s:auto_preview_line = -1
+                \ if !s:exec_python | call s:MundoRefresh() | endif
+    autocmd BufLeave __Mundo__
+                \ if !s:exec_python | call s:MundoStopRefreshTimer() | endif
+    autocmd BufEnter __Mundo__
+                \ if !s:exec_python | let s:auto_preview_line = -1 | endif
 augroup END"}}}
 
 "}}}
 
+" Exposed functions{{{
+
+function! mundo#MundoToggle()"{{{
+    call s:MundoToggle()
+endfunction"}}}
+
+function! mundo#MundoShow()"{{{
+    call s:MundoShow()
+endfunction"}}}
+
+function! mundo#MundoHide()"{{{
+    call s:MundoHide()
+endfunction"}}}
+
+function! mundo#MundoRenderGraph()"{{{
+    call s:MundoPythonRestoreView('MundoRenderGraph()')
+endfunction"}}}
+
+"}}}
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/autoload/mundo/node.py
+++ b/autoload/mundo/node.py
@@ -34,7 +34,7 @@ class Nodes(object):
         self.diff_has_oneline = {}
 
     def _check_version_location(self):
-        util._goto_window_for_buffer(util.vim().eval('g:mundo_target_n'))
+        util._goto_window_for_buffer(int(util.vim().eval('g:mundo_target_n')))
         target_f = util.vim().eval('g:mundo_target_f')
         if target_f != self.target_f:
             self._clear_cache()
@@ -46,14 +46,15 @@ class Nodes(object):
             if alt:
                 curhead = 'curhead' in alt
                 saved = 'save' in alt
-                node = Node(n=alt['seq'], parent=p, time=alt['time'], curhead=curhead, saved=saved)
+                node = Node(n=alt['seq'], parent=p, time=alt['time'],
+                            curhead=curhead, saved=saved)
                 nodes.append(node)
                 if alt.get('alt'):
                     self._make_nodes(alt['alt'], nodes, p)
                 p = node
 
     def is_outdated(self):
-        util._goto_window_for_buffer(util.vim().eval('g:mundo_target_n'))
+        util._goto_window_for_buffer(int(util.vim().eval('g:mundo_target_n')))
         current_changedtick = util.vim().eval('b:changedtick')
         return self.changedtick != current_changedtick
 
@@ -114,7 +115,7 @@ class Nodes(object):
         if key in self.diffs:
             return self.diffs[key]
 
-        util._goto_window_for_buffer(util.vim().eval('g:mundo_target_n'))
+        util._goto_window_for_buffer(int(util.vim().eval('g:mundo_target_n')))
         before_lines = self._get_lines(before)
         after_lines = self._get_lines(after)
 
@@ -183,12 +184,15 @@ class Nodes(object):
             after_time = self._fmt_time(after.time)
 
         if unified:
-            self.diffs[key] = list(difflib.unified_diff(before_lines, after_lines,
-                                             before_name, after_name,
-                                             before_time, after_time))
+            self.diffs[key] = list(
+                difflib.unified_diff(before_lines, after_lines, before_name,
+                                     after_name, before_time, after_time)
+            )
         elif inline:
             maxwidth = int(util.vim().eval("winwidth(0)"))
-            self.diffs[key] = diff.one_line_diff_str('\n'.join(before_lines),'\n'.join(after_lines),maxwidth)
+            self.diffs[key] = diff.one_line_diff_str(
+                '\n'.join(before_lines),'\n'.join(after_lines), maxwidth
+            )
             self.diff_has_oneline[key] = True
         else:
             self.diffs[key] = ""

--- a/autoload/mundo/util.py
+++ b/autoload/mundo/util.py
@@ -12,7 +12,6 @@ def vim():
     import vim
     return vim
 
-
 def _goto_window_for_buffer(expr):
     """ Moves the cursor to the first window associated with buffer b in the
         current tab page (only).

--- a/autoload/mundo/util.py
+++ b/autoload/mundo/util.py
@@ -3,28 +3,45 @@
 normal = lambda s: vim().command('normal %s' % s)
 normal_silent = lambda s: vim().command('silent! normal %s' % s)
 
+
 def vim():
     """ call Vim.
-    
-    This is wrapped so that it can easily be mocked.
+
+        This is wrapped so that it can easily be mocked.
     """
     import vim
     return vim
 
-def _goto_window_for_buffer(b):
-    w = int(vim().eval('bufwinnr(%d)' % int(b)))
-    vim().command('%dwincmd w' % int(w))
 
-def _goto_window_for_buffer_name(bn):
-    b = vim().eval('bufnr("%s")' % bn)
-    return _goto_window_for_buffer(b)
+def _goto_window_for_buffer(expr):
+    """ Moves the cursor to the first window associated with buffer b in the
+        current tab page (only).
+
+        Arguments
+        ---------
+        expr : int or str
+            The target buffer - either a buffer number (int) or a file-pattern
+            (str). See :h bufwinnr for a more detailed description.
+    """
+    if not isinstance(expr, int) and not isinstance(expr, str):
+        raise TypeError('b has invalid type, str or int expected.')
+
+    if isinstance(expr, str):
+        expr = "'{0}'".format(expr)
+
+    winnr = int(vim().eval('bufwinnr({0})'.format(expr)))
+    assert winnr != -1
+    vim().command('%dwincmd w' % int(winnr))
+
 
 # Rendering utility functions
 def _output_preview_text(lines):
-    _goto_window_for_buffer_name('__Mundo_Preview__')
+    """ Output a list of lines to the mundo preview window. """
+    _goto_window_for_buffer('__Mundo_Preview__')
     vim().command('setlocal modifiable')
     vim().current.buffer[:] = [line.rstrip() for line in lines]
     vim().command('setlocal nomodifiable')
+
 
 def _undo_to(n):
     n = int(n)

--- a/autoload/mundo/util.vim
+++ b/autoload/mundo/util.vim
@@ -47,14 +47,15 @@ function! mundo#util#GoToBufferGlobal(expr)"{{{
     return 1
 endfunction"}}}
 
-" Prints a given message with a given highlight group.
+" Prints a highlighted string.
 function! mundo#util#Echo(higroup, text)"{{{
-    exec 'echohl ' . a:higroup . ' | echomsg ' . '"' . escape(a:text, '"')
-                \ . '" | echohl None'
+    execute 'echohl ' . a:higroup
+    execute 'unsilent echomsg ' . '"' . escape(a:text, '"') . '"'
+    echohl None
 endfunction"}}}
 
 " Set var to val only if var has not been set by the user. Optionally takes a
-" deprecated name and shows a warning if a matching option has been set.
+" deprecated option name and shows a warning if a variable with this name exists.
 function! mundo#util#set_default(var, val, ...)"{{{
     if !exists(a:var)
         let {a:var} = a:val

--- a/autoload/mundo/util.vim
+++ b/autoload/mundo/util.vim
@@ -1,124 +1,109 @@
+" ============================================================================
+" File:        util.vim
+" Description: Defines utility functions and default option values for Mundo.
+" Maintainer:  Hyeon Kim <simnalamburt@gmail.com>
+" License:     GPLv2+
+" ============================================================================
+
 let s:save_cpo = &cpo
 set cpo&vim
 
 if exists('g:Mundo_PluginLoaded')
+    let &cpo = s:save_cpo
     finish
 endif
 
-function! mundo#util#set_default(var, val, ...)  "{{{
+" Utility functions{{{
+
+" Moves to the first window in the current tab corresponding to expr. Accepts
+" an integer buffer number or a string file-pattern; for a detailed description
+" see :h bufname. Returns 1 if successful, 0 otherwise.
+function! mundo#util#MundoGoToWindowForBuffer(expr)"{{{
+    let l:winnr = bufwinnr(bufnr(a:expr))
+
+    if l:winnr == -1
+        return 0
+    elseif l:winnr != winnr()
+        exe l:winnr . "wincmd w"
+    endif
+
+    return 1
+endfunction"}}}
+
+" Similar to MundoGoToWindowForBuffer, but considers windows in all tabs.
+" Prioritises matches in the current tab.
+function! mundo#util#MundoGoToWindowForBufferGlobal(expr)"{{{
+    if mundo#util#MundoGoToWindowForBuffer(a:expr)
+        return 1
+    endif
+
+    let l:bufWinIDs = win_findbuf(bufnr(a:expr))
+
+    if len(l:bufWinIDs) <= 0
+        return 0
+    endif
+
+    call win_gotoid(l:bufWinIDs[0])
+    return 1
+endfunction"}}}
+
+" Prints a given message with a given highlight group.
+function! mundo#util#Message(higroup, text)"{{{
+    exec 'echohl ' . a:higroup . ' | echomsg ' . '"' . a:text
+                \ . '" | echohl None'
+endfunction"}}}
+
+" Set var to val only if var has not been set by the user. Optionally takes a
+" deprecated name and shows a warning if a matching option has been set.
+function! mundo#util#SetOptionDefault(var, val, ...)"{{{
     if !exists(a:var)
         let {a:var} = a:val
     endif
+
     let old_var = get(a:000, 0, '')
+
     if exists(old_var)
-        echohl WarningMsg
-        echomsg "{".old_var."}is deprecated! Please change your setting to {"
-                    \.split(old_var,':')[0]
-                    \.':'
-                    \.substitute(split(old_var,':')[1],'gundo_','mundo_','g')
-                    \.'}'
-        echohl None
+        call mundo#util#Message(
+                    \ 'WarningMsg',
+                    \ "{".old_var."}is deprecated! "
+                    \ ."Please change your setting to {"
+                    \ .split(old_var,':')[0]
+                    \ .':'
+                    \ .substitute(split(old_var,':')[1],'gundo_','mundo_','g')
+                    \ .'}'
+        )
     endif
 endfunction"}}}
 
-call mundo#util#set_default(
-            \ 'g:mundo_python_path_setup', 0,
-            \ 'g:gundo_python_path_setup')
+"}}}
 
-call mundo#util#set_default(
-            \ 'g:mundo_first_visible_line', 0,
-            \ 'g:gundo_first_visible_line')
+" Placeholder functions for deprecated Gundo commands{{{
 
-call mundo#util#set_default(
-            \ 'g:mundo_last_visible_line', 0,
-            \ 'g:gundo_last_visible_line')
-
-call mundo#util#set_default(
-            \ 'g:mundo_width', 45,
-            \ 'g:gundo_width')
-
-call mundo#util#set_default(
-            \ 'g:mundo_preview_height', 15,
-            \ 'g:gundo_preview_height')
-
-call mundo#util#set_default(
-            \ 'g:mundo_preview_bottom', 0,
-            \ 'g:gundo_preview_bottom')
-
-call mundo#util#set_default(
-            \ 'g:mundo_right', 0,
-            \ 'g:gundo_right')
-
-call mundo#util#set_default(
-            \ 'g:mundo_help', 0,
-            \ 'g:gundo_help')
-
-call mundo#util#set_default(
-            \ 'g:mundo_map_move_older', 'j',
-            \ 'g:gundo_map_move_older')
-
-call mundo#util#set_default(
-            \ 'g:mundo_map_move_newer', 'k',
-            \ 'g:gundo_map_move_newer')
-
-call mundo#util#set_default(
-            \ 'g:mundo_close_on_revert', 0,
-            \ 'g:gundo_close_on_revert')
-
-call mundo#util#set_default(
-            \ 'g:mundo_prefer_python3', 0,
-            \ 'g:gundo_prefer_python3')
-
-call mundo#util#set_default(
-            \ 'g:mundo_auto_preview', 1,
-            \ 'g:gundo_auto_preview')
-
-call mundo#util#set_default(
-            \ 'g:mundo_verbose_graph', 1,
-            \ 'g:gundo_verbose_graph')
-
-call mundo#util#set_default(
-            \ 'g:mundo_playback_delay', 60,
-            \ 'g:gundo_playback_delay')
-
-call mundo#util#set_default(
-            \ 'g:mundo_mirror_graph', 0,
-            \ 'g:gundo_mirror_graph')
-
-call mundo#util#set_default(
-            \ 'g:mundo_inline_undo', 0,
-            \ 'g:gundo_inline_undo')
-
-call mundo#util#set_default(
-            \ 'g:mundo_return_on_revert', 1,
-            \ 'g:gundo_return_on_revert')
-
-call mundo#util#set_default('g:mundo_auto_preview_delay', 250)
-
-function! mundo#util#init() abort
-
-endfunction
-
-func! mundo#util#MundoToggle()
-    echohl WarningMsg
-    echomsg "GundoToggle commands are deprecated. Please change to their corresponding MundoToggle command"
-    echohl None
+function! mundo#util#MundoToggle()
+    return mundo#util#Message('WarningMsg', 'GundoToggle commands are '
+                \ . 'deprecated. Please change to their corresponding '
+                \ . 'MundoToggle command.')
 endf
-func! mundo#util#MundoShow()
-    echohl WarningMsg
-    echomsg "GundoShow commands are deprecated. Please change to their corresponding MundoShow command"
-    echohl None
+
+function! mundo#util#MundoShow()
+    return mundo#util#Message('WarningMsg', 'GundoToggle commands are '
+                \ . 'deprecated. Please change to their corresponding '
+                \ . 'MundoShow command.')
 endf
-func! mundo#util#MundoHide()
-    echohl WarningMsg
-    echomsg "GundoHide commands are deprecated. Please change to their corresponding MundoHide command"
-    echohl None
+
+function! mundo#util#MundoHide()
+    return mundo#util#Message('WarningMsg', 'GundoToggle commands are '
+                \ . 'deprecated. Please change to their corresponding '
+                \ . 'MundoHide command.')
 endf
-func! mundo#util#MundoRenderGraph()
-    echohl WarningMsg
-    echomsg "GundoRenderGraph commands are deprecated. Please change to their corresponding MundoRenderGraph command"
-    echohl None
+
+function! mundo#util#MundoRenderGraph()
+    return mundo#util#Message('WarningMsg', 'GundoToggle commands are '
+                \ . 'deprecated. Please change to their corresponding '
+                \ . 'MundoRenderGraph command.')
 endf
+
+"}}}
 
 let g:Mundo_PluginLoaded = 1
 

--- a/autoload/mundo/util.vim
+++ b/autoload/mundo/util.vim
@@ -93,6 +93,8 @@ call mundo#util#set_default(
             \ 'g:mundo_return_on_revert', 1,
             \ 'g:gundo_return_on_revert')
 
+call mundo#util#set_default('g:mundo_auto_preview_delay', 250)
+
 function! mundo#util#init() abort
 
 endfunction

--- a/autoload/mundo/util.vim
+++ b/autoload/mundo/util.vim
@@ -18,7 +18,7 @@ endif
 " Moves to the first window in the current tab corresponding to expr. Accepts
 " an integer buffer number or a string file-pattern; for a detailed description
 " see :h bufname. Returns 1 if successful, 0 otherwise.
-function! mundo#util#MundoGoToWindowForBuffer(expr)"{{{
+function! mundo#util#GoToBuffer(expr)"{{{
     let l:winnr = bufwinnr(bufnr(a:expr))
 
     if l:winnr == -1
@@ -30,10 +30,10 @@ function! mundo#util#MundoGoToWindowForBuffer(expr)"{{{
     return 1
 endfunction"}}}
 
-" Similar to MundoGoToWindowForBuffer, but considers windows in all tabs.
+" Similar to MundoGoToBuffer, but considers windows in all tabs.
 " Prioritises matches in the current tab.
-function! mundo#util#MundoGoToWindowForBufferGlobal(expr)"{{{
-    if mundo#util#MundoGoToWindowForBuffer(a:expr)
+function! mundo#util#GoToBufferGlobal(expr)"{{{
+    if mundo#util#GoToBuffer(a:expr)
         return 1
     endif
 
@@ -48,8 +48,8 @@ function! mundo#util#MundoGoToWindowForBufferGlobal(expr)"{{{
 endfunction"}}}
 
 " Prints a given message with a given highlight group.
-function! mundo#util#Message(higroup, text)"{{{
-    exec 'echohl ' . a:higroup . ' | echomsg ' . '"' . a:text
+function! mundo#util#Echo(higroup, text)"{{{
+    exec 'echohl ' . a:higroup . ' | echomsg ' . '"' . escape(a:text, '"')
                 \ . '" | echohl None'
 endfunction"}}}
 
@@ -63,7 +63,7 @@ function! mundo#util#set_default(var, val, ...)"{{{
     let old_var = get(a:000, 0, '')
 
     if exists(old_var)
-        call mundo#util#Message(
+        call mundo#util#Echo(
                     \ 'WarningMsg',
                     \ "{".old_var."}is deprecated! "
                     \ ."Please change your setting to {"
@@ -79,26 +79,26 @@ endfunction"}}}
 
 " Placeholder functions for deprecated Gundo commands{{{
 
-function! mundo#util#MundoToggle()
-    return mundo#util#Message('WarningMsg', 'GundoToggle commands are '
+function! mundo#util#Toggle()
+    return mundo#util#Echo('WarningMsg', 'GundoToggle commands are '
                 \ . 'deprecated. Please change to their corresponding '
                 \ . 'MundoToggle command.')
 endf
 
-function! mundo#util#MundoShow()
-    return mundo#util#Message('WarningMsg', 'GundoToggle commands are '
+function! mundo#util#Show()
+    return mundo#util#Echo('WarningMsg', 'GundoToggle commands are '
                 \ . 'deprecated. Please change to their corresponding '
                 \ . 'MundoShow command.')
 endf
 
-function! mundo#util#MundoHide()
-    return mundo#util#Message('WarningMsg', 'GundoToggle commands are '
+function! mundo#util#Hide()
+    return mundo#util#Echo('WarningMsg', 'GundoToggle commands are '
                 \ . 'deprecated. Please change to their corresponding '
                 \ . 'MundoHide command.')
 endf
 
-function! mundo#util#MundoRenderGraph()
-    return mundo#util#Message('WarningMsg', 'GundoToggle commands are '
+function! mundo#util#RenderGraph()
+    return mundo#util#Echo('WarningMsg', 'GundoToggle commands are '
                 \ . 'deprecated. Please change to their corresponding '
                 \ . 'MundoRenderGraph command.')
 endf

--- a/autoload/mundo/util.vim
+++ b/autoload/mundo/util.vim
@@ -55,7 +55,7 @@ endfunction"}}}
 
 " Set var to val only if var has not been set by the user. Optionally takes a
 " deprecated name and shows a warning if a matching option has been set.
-function! mundo#util#SetOptionDefault(var, val, ...)"{{{
+function! mundo#util#set_default(var, val, ...)"{{{
     if !exists(a:var)
         let {a:var} = a:val
     endif

--- a/doc/mundo.txt
+++ b/doc/mundo.txt
@@ -25,7 +25,7 @@ CONTENTS                                                      *Mundo-contents*
         3.13 mundo_playback_delay ...... |mundo_playback_delay|
         3.14 mundo_mirror_graph ........ |mundo_mirror_graph|
         3.15 mundo_inline_undo ......... |mundo_inline_undo|
-        3.16 mundo_inline_undo_delay ... |mundo_inline_undo_delay|
+        3.16 mundo_enable_inline_delay ... |mundo_enable_inline_delay|
         3.17 mundo_return_on_revert .... |mundo_return_on_revert|
     4. License ......................... |MundoLicense|
     5. Bugs ............................ |MundoBugs|
@@ -269,7 +269,7 @@ provides a quick summary of the diff w/o having to navigate.
 Default: 0 (no inline graph)
 
 -----------------------------------------------------------------------------
-3.16 g:mundo_inline_undo_delay                      *mundo_inline_undo_delay*
+3.16 g:mundo_enable_inline_delay                   *mundo_enable_inline_delay*
 
 When this option is set, inline diff rendering will be delayed until a preview
 diff is rendered. Use this to speed up undo tree traversal when inline diffs

--- a/doc/mundo.txt
+++ b/doc/mundo.txt
@@ -20,11 +20,13 @@ CONTENTS                                                      *Mundo-contents*
         3.9  mundo_preview_statusline .. |mundo_preview_statusline|
              mundo_tree_statusline ..... |mundo_tree_statusline|
         3.10 mundo_auto_preview ........ |mundo_auto_preview|
-        3.11 mundo_verbose_graph ....... |mundo_verbose_graph|
-        3.12 mundo_playback_delay ...... |mundo_playback_delay|
-        3.13 mundo_mirror_graph ........ |mundo_mirror_graph|
-        3.14 mundo_inline_undo ......... |mundo_inline_undo|
-        3.15 mundo_return_on_revert .... |mundo_return_on_revert|
+        3.11 mundo_auto_preview_delay .. |mundo_auto_preview_delay|
+        3.12 mundo_verbose_graph ....... |mundo_verbose_graph|
+        3.13 mundo_playback_delay ...... |mundo_playback_delay|
+        3.14 mundo_mirror_graph ........ |mundo_mirror_graph|
+        3.15 mundo_inline_undo ......... |mundo_inline_undo|
+        3.16 mundo_inline_undo_delay ... |mundo_inline_undo_delay|
+        3.17 mundo_return_on_revert .... |mundo_return_on_revert|
     4. License ......................... |MundoLicense|
     5. Bugs ............................ |MundoBugs|
     6. Contributing .................... |MundoContributing|
@@ -223,7 +225,17 @@ be useful on large files and undo trees to speed up Mundo.
 Default: 1 (automatically preview diffs)
 
 ------------------------------------------------------------------------------
-3.11 g:mundo_verbose_graph                               *mundo_verbose_graph*
+
+3.11 g:mundo_auto_preview_delay                     *mundo_auto_preview_delay*
+
+This is the delay in milliseconds before a preview diff is automatically 
+rendered. The delay is reset whenever the cursor moves. Use this to speed up 
+undo tree traversal when automatic previews are enabled.
+
+Default: 0 (no delay)
+
+------------------------------------------------------------------------------
+3.12 g:mundo_verbose_graph                               *mundo_verbose_graph*
 
 Set this to 0 to create shorter graphs: the 'o' characters will only be used
 when multiple branches exist, and extra lines of '|' are suppressed making for
@@ -232,7 +244,7 @@ a graph half as long.
 Default: 1 (verbose graphs)
 
 ------------------------------------------------------------------------------
-3.12 g:mundo_playback_delay                             *mundo_playback_delay*
+3.13 g:mundo_playback_delay                             *mundo_playback_delay*
 
 This is the delay in milliseconds between each change when running 'play to'
 mode. Set this to a higher number for a slower playback or to a lower number
@@ -241,14 +253,14 @@ for a faster playback.
 Default: 60
 
 ------------------------------------------------------------------------------
-3.13 g:mundo_mirror_graph                                *mundo_mirror_graph*
+3.14 g:mundo_mirror_graph                                *mundo_mirror_graph*
 
 Set this to 0 to align the graph to the left; set to 1 to align to the right.
 
 Default: 1 (mirror graph)
 
 ------------------------------------------------------------------------------
-3.14 g:mundo_inline_undo                                 *mundo_inline_undo*
+3.15 g:mundo_inline_undo                                 *mundo_inline_undo*
 
 When enabled, a small one line diff is displayed to the right of the graph undo.
 Although not as detailed as a full diff provided in the preview window, it
@@ -256,8 +268,17 @@ provides a quick summary of the diff w/o having to navigate.
 
 Default: 0 (no inline graph)
 
+-----------------------------------------------------------------------------
+3.16 g:mundo_inline_undo_delay                      *mundo_inline_undo_delay*
+
+When this option is set, inline diff rendering will be delayed until a preview
+diff is rendered. Use this to speed up undo tree traversal when inline diffs
+are enabled.
+
+Default: 0 (disabled)
+
 ------------------------------------------------------------------------------
-3.15 g:mundo_return_on_revert                         *mundo_return_on_revert*
+3.17 g:mundo_return_on_revert                         *mundo_return_on_revert*
 
 Set this to 0 to keep focus in the Mundo window after a revert.
 

--- a/doc/mundo.txt
+++ b/doc/mundo.txt
@@ -311,14 +311,19 @@ GitHub: https://github.com/simnalamburt/vim-mundo
 
 
 v3.1.0
-    * Adds g:mundo_auto_preview_delay and g:mundo_map_up_down settings.
-    * Adds validation for target buffer when attempting to open Mundo.
-    * Fix runtime error when entering embedded terminal windows in neovim.
+    * Adds g:mundo_map_up_down setting.
+    * Adds g:mundo_auto_preview_delay setting.
+    * Adds validation for target buffers.
+    * Adds 'G' mapping to graph.
+    * Fix a runtime error when entering embedded terminal windows in neovim.
     * Fix multiple issues associated with Mundo windows in different tabs.
     * Fix default option values overriding user-set values in certain cases.
     * Fix cursor initially being positioned above the graph.
-    * Fix graph and preview mapping bugs occuring when v:count was set.
+    * Fix some mappings not working correctly when preceded with a count.
     * Fix some graph mappings moving the cursor to the target buffer.
+    * Fix airline plugin ignoring custom status lines.
+    * Fix Escape and Ctrl+c not being handled correctly in the search prompt.
+    * Fix MundoGetTargetState returning invalid results with some inline diffs.
     * Reduced delay associated with animated playback for neovim.
     * Code cleanup and refactoring.
 v3.0.1

--- a/doc/mundo.txt
+++ b/doc/mundo.txt
@@ -26,6 +26,7 @@ CONTENTS                                                      *Mundo-contents*
         3.14 mundo_mirror_graph ........ |mundo_mirror_graph|
         3.15 mundo_inline_undo ......... |mundo_inline_undo|
         3.16 mundo_return_on_revert .... |mundo_return_on_revert|
+        3.17 mundo_map_up_down ......... |mundo_map_up_down|
     4. License ......................... |MundoLicense|
     5. Bugs ............................ |MundoBugs|
     6. Contributing .................... |MundoContributing|
@@ -227,8 +228,8 @@ Default: 1 (automatically preview diffs)
 
 3.11 g:mundo_auto_preview_delay                     *mundo_auto_preview_delay*
 
-This is the delay in milliseconds before a preview diff is automatically 
-rendered. The delay is reset whenever the cursor moves. Use this to speed up 
+This is the delay in milliseconds before a preview diff is automatically
+rendered. The delay is reset whenever the cursor moves. Use this to speed up
 undo tree traversal when automatic previews are enabled. Set this to 0 to
 disable the feature.
 
@@ -262,8 +263,8 @@ Default: 1 (mirror graph)
 ------------------------------------------------------------------------------
 3.15 g:mundo_inline_undo                                   *mundo_inline_undo*
 
-When enabled, a small one line diff is displayed to the right of the graph 
-undo. Although not as detailed as a full diff provided in the preview window, 
+When enabled, a small one line diff is displayed to the right of the graph
+undo. Although not as detailed as a full diff provided in the preview window,
 it provides a quick summary of the diff w/o having to navigate.
 
 Default: 0 (no inline graph)
@@ -272,6 +273,14 @@ Default: 0 (no inline graph)
 3.16 g:mundo_return_on_revert                         *mundo_return_on_revert*
 
 Set this to 0 to keep focus in the Mundo window after a revert.
+
+Default: 1
+
+------------------------------------------------------------------------------
+3.17 g:mundo_map_up_down                                   *mundo_map_up_down*
+
+By default, <Up> and <Down> are mapped to navigate up and down the undo graph.
+Set this to 0 to prevent these mappings.
 
 Default: 1
 
@@ -302,7 +311,16 @@ GitHub: https://github.com/simnalamburt/vim-mundo
 
 
 v3.1.0
-    * Added g:mundo_auto_preview_delay setting.
+    * Adds g:mundo_auto_preview_delay and g:mundo_map_up_down settings.
+    * Adds validation for target buffer when attempting to open Mundo.
+    * Fix runtime error when entering embedded terminal windows in neovim.
+    * Fix multiple issues associated with Mundo windows in different tabs.
+    * Fix default option values overriding user-set values in certain cases.
+    * Fix cursor initially being positioned above the graph.
+    * Fix graph and preview mapping bugs occuring when v:count was set.
+    * Fix some graph mappings moving the cursor to the target buffer.
+    * Reduced delay associated with animated playback for neovim.
+    * Code cleanup and refactoring.
 v3.0.1
     * Made inline diff mode much faster(e.g. 300x)
     * Fix inline diffs not updating after scroll.

--- a/doc/mundo.txt
+++ b/doc/mundo.txt
@@ -273,7 +273,7 @@ Default: 0 (no inline graph)
 
 When this option is set, inline diff rendering will be delayed until a preview
 diff is rendered. Use this to speed up undo tree traversal when inline diffs
-are enabled.
+and delayed automatic previews are both enabled.
 
 Default: 0 (disabled)
 

--- a/doc/mundo.txt
+++ b/doc/mundo.txt
@@ -25,8 +25,7 @@ CONTENTS                                                      *Mundo-contents*
         3.13 mundo_playback_delay ...... |mundo_playback_delay|
         3.14 mundo_mirror_graph ........ |mundo_mirror_graph|
         3.15 mundo_inline_undo ......... |mundo_inline_undo|
-        3.16 mundo_enable_inline_delay ... |mundo_enable_inline_delay|
-        3.17 mundo_return_on_revert .... |mundo_return_on_revert|
+        3.16 mundo_return_on_revert .... |mundo_return_on_revert|
     4. License ......................... |MundoLicense|
     5. Bugs ............................ |MundoBugs|
     6. Contributing .................... |MundoContributing|
@@ -230,9 +229,10 @@ Default: 1 (automatically preview diffs)
 
 This is the delay in milliseconds before a preview diff is automatically 
 rendered. The delay is reset whenever the cursor moves. Use this to speed up 
-undo tree traversal when automatic previews are enabled.
+undo tree traversal when automatic previews are enabled. Set this to 0 to
+disable the feature.
 
-Default: 0 (no delay)
+Default: 250
 
 ------------------------------------------------------------------------------
 3.12 g:mundo_verbose_graph                               *mundo_verbose_graph*
@@ -253,32 +253,23 @@ for a faster playback.
 Default: 60
 
 ------------------------------------------------------------------------------
-3.14 g:mundo_mirror_graph                                *mundo_mirror_graph*
+3.14 g:mundo_mirror_graph                                 *mundo_mirror_graph*
 
 Set this to 0 to align the graph to the left; set to 1 to align to the right.
 
 Default: 1 (mirror graph)
 
 ------------------------------------------------------------------------------
-3.15 g:mundo_inline_undo                                 *mundo_inline_undo*
+3.15 g:mundo_inline_undo                                   *mundo_inline_undo*
 
-When enabled, a small one line diff is displayed to the right of the graph undo.
-Although not as detailed as a full diff provided in the preview window, it
-provides a quick summary of the diff w/o having to navigate.
+When enabled, a small one line diff is displayed to the right of the graph 
+undo. Although not as detailed as a full diff provided in the preview window, 
+it provides a quick summary of the diff w/o having to navigate.
 
 Default: 0 (no inline graph)
 
------------------------------------------------------------------------------
-3.16 g:mundo_enable_inline_delay                   *mundo_enable_inline_delay*
-
-When this option is set, inline diff rendering will be delayed until a preview
-diff is rendered. Use this to speed up undo tree traversal when inline diffs
-and delayed automatic previews are both enabled.
-
-Default: 0 (disabled)
-
 ------------------------------------------------------------------------------
-3.17 g:mundo_return_on_revert                         *mundo_return_on_revert*
+3.16 g:mundo_return_on_revert                         *mundo_return_on_revert*
 
 Set this to 0 to keep focus in the Mundo window after a revert.
 
@@ -302,11 +293,16 @@ https://github.com/simnalamburt/vim-mundo/issues
 Think you can make this plugin better? Awesome. Fork it on BitBucket or GitHub
 and send a pull request.
 
+Version numbers should roughly follow Semantic Versioning.
+
 GitHub: https://github.com/simnalamburt/vim-mundo
 
 ==============================================================================
 7. Changelog                                                  *MundoChangelog*
 
+
+v3.1.0
+    * Added g:mundo_auto_preview_delay setting.
 v3.0.1
     * Made inline diff mode much faster(e.g. 300x)
     * Fix inline diffs not updating after scroll.
@@ -341,8 +337,8 @@ v2.2.0
     * Fix a bug with the splitbelow setting.
 v2.1.1
     * Fix a bug with the movement key mappings.
-v2.1.0
     * Warnings about having an incompatible Vim and/or Python installation
+v2.1.0
       are now deferred until the first time you try to use Mundo, instead
       of being displayed on launch.
     * The <j> and <k> mappings are now configurable with

--- a/plugin/mundo.vim
+++ b/plugin/mundo.vim
@@ -17,77 +17,81 @@ let loaded_mundo = 1"}}}
 
 " Default option values{{{
 
-call mundo#util#SetOptionDefault(
+call mundo#util#set_default(
             \ 'g:mundo_auto_preview', 1,
             \ 'g:gundo_auto_preview')
 
-call mundo#util#SetOptionDefault('g:mundo_auto_preview_delay', 250)
+call mundo#util#set_default('g:mundo_auto_preview_delay', 250)
 
-call mundo#util#SetOptionDefault(
+call mundo#util#set_default(
             \ 'g:mundo_close_on_revert', 0,
             \ 'g:gundo_close_on_revert')
 
-call mundo#util#SetOptionDefault(
+call mundo#util#set_default(
             \ 'g:mundo_first_visible_line', 0,
             \ 'g:gundo_first_visible_line')
 
-call mundo#util#SetOptionDefault(
+call mundo#util#set_default(
             \ 'g:mundo_help', 0,
             \ 'g:gundo_help')
 
-call mundo#util#SetOptionDefault(
+call mundo#util#set_default(
             \ 'g:mundo_inline_undo', 0,
             \ 'g:gundo_inline_undo')
 
-call mundo#util#SetOptionDefault(
+call mundo#util#set_default(
             \ 'g:mundo_last_visible_line', 0,
             \ 'g:gundo_last_visible_line')
 
-call mundo#util#SetOptionDefault(
+call mundo#util#set_default(
             \ 'g:mundo_map_move_newer', 'k',
             \ 'g:gundo_map_move_newer')
 
-call mundo#util#SetOptionDefault(
+call mundo#util#set_default(
             \ 'g:mundo_map_move_older', 'j',
             \ 'g:gundo_map_move_older')
 
-call mundo#util#SetOptionDefault(
+call mundo#util#set_default(
+            \ 'g:mundo_map_up_down', 1,
+            \ 'g:gundo_map_up_down')
+
+call mundo#util#set_default(
             \ 'g:mundo_mirror_graph', 0,
             \ 'g:gundo_mirror_graph')
 
-call mundo#util#SetOptionDefault(
+call mundo#util#set_default(
             \ 'g:mundo_playback_delay', 60,
             \ 'g:gundo_playback_delay')
 
-call mundo#util#SetOptionDefault(
+call mundo#util#set_default(
             \ 'g:mundo_prefer_python3', 0,
             \ 'g:gundo_prefer_python3')
 
-call mundo#util#SetOptionDefault(
+call mundo#util#set_default(
             \ 'g:mundo_preview_bottom', 0,
             \ 'g:gundo_preview_bottom')
 
-call mundo#util#SetOptionDefault(
+call mundo#util#set_default(
             \ 'g:mundo_preview_height', 15,
             \ 'g:gundo_preview_height')
 
-call mundo#util#SetOptionDefault(
+call mundo#util#set_default(
             \ 'g:mundo_python_path_setup', 0,
             \ 'g:gundo_python_path_setup')
 
-call mundo#util#SetOptionDefault(
+call mundo#util#set_default(
             \ 'g:mundo_return_on_revert', 1,
             \ 'g:gundo_return_on_revert')
 
-call mundo#util#SetOptionDefault(
+call mundo#util#set_default(
             \ 'g:mundo_right', 0,
             \ 'g:gundo_right')
 
-call mundo#util#SetOptionDefault(
+call mundo#util#set_default(
             \ 'g:mundo_verbose_graph', 1,
             \ 'g:gundo_verbose_graph')
 
-call mundo#util#SetOptionDefault(
+call mundo#util#set_default(
             \ 'g:mundo_width', 45,
             \ 'g:gundo_width')
 

--- a/plugin/mundo.vim
+++ b/plugin/mundo.vim
@@ -8,15 +8,93 @@
 "
 " ============================================================================
 
-
-"{{{ Init
-if !exists('g:mundo_debug') && (exists('g:mundo_disable') && g:mundo_disable == 1 || exists('loaded_mundo') || &cp)"{{{
+if !exists('g:mundo_debug') && (exists('g:mundo_disable') &&
+            \ g:mundo_disable == 1 || exists('loaded_mundo') || &cp)"{{{
     finish
 endif
+
 let loaded_mundo = 1"}}}
+
+" Default option values{{{
+
+call mundo#util#SetOptionDefault(
+            \ 'g:mundo_auto_preview', 1,
+            \ 'g:gundo_auto_preview')
+
+call mundo#util#SetOptionDefault('g:mundo_auto_preview_delay', 250)
+
+call mundo#util#SetOptionDefault(
+            \ 'g:mundo_close_on_revert', 0,
+            \ 'g:gundo_close_on_revert')
+
+call mundo#util#SetOptionDefault(
+            \ 'g:mundo_first_visible_line', 0,
+            \ 'g:gundo_first_visible_line')
+
+call mundo#util#SetOptionDefault(
+            \ 'g:mundo_help', 0,
+            \ 'g:gundo_help')
+
+call mundo#util#SetOptionDefault(
+            \ 'g:mundo_inline_undo', 0,
+            \ 'g:gundo_inline_undo')
+
+call mundo#util#SetOptionDefault(
+            \ 'g:mundo_last_visible_line', 0,
+            \ 'g:gundo_last_visible_line')
+
+call mundo#util#SetOptionDefault(
+            \ 'g:mundo_map_move_newer', 'k',
+            \ 'g:gundo_map_move_newer')
+
+call mundo#util#SetOptionDefault(
+            \ 'g:mundo_map_move_older', 'j',
+            \ 'g:gundo_map_move_older')
+
+call mundo#util#SetOptionDefault(
+            \ 'g:mundo_mirror_graph', 0,
+            \ 'g:gundo_mirror_graph')
+
+call mundo#util#SetOptionDefault(
+            \ 'g:mundo_playback_delay', 60,
+            \ 'g:gundo_playback_delay')
+
+call mundo#util#SetOptionDefault(
+            \ 'g:mundo_prefer_python3', 0,
+            \ 'g:gundo_prefer_python3')
+
+call mundo#util#SetOptionDefault(
+            \ 'g:mundo_preview_bottom', 0,
+            \ 'g:gundo_preview_bottom')
+
+call mundo#util#SetOptionDefault(
+            \ 'g:mundo_preview_height', 15,
+            \ 'g:gundo_preview_height')
+
+call mundo#util#SetOptionDefault(
+            \ 'g:mundo_python_path_setup', 0,
+            \ 'g:gundo_python_path_setup')
+
+call mundo#util#SetOptionDefault(
+            \ 'g:mundo_return_on_revert', 1,
+            \ 'g:gundo_return_on_revert')
+
+call mundo#util#SetOptionDefault(
+            \ 'g:mundo_right', 0,
+            \ 'g:gundo_right')
+
+call mundo#util#SetOptionDefault(
+            \ 'g:mundo_verbose_graph', 1,
+            \ 'g:gundo_verbose_graph')
+
+call mundo#util#SetOptionDefault(
+            \ 'g:mundo_width', 45,
+            \ 'g:gundo_width')
+
 "}}}
 
-"{{{ Misc
+"{{{ Create commands
+
 command! -nargs=0 MundoToggle call mundo#MundoToggle()
 command! -nargs=0 MundoShow call mundo#MundoShow()
 command! -nargs=0 MundoHide call mundo#MundoHide()
@@ -25,4 +103,5 @@ command! -nargs=0 GundoToggle call mundo#util#MundoToggle()
 command! -nargs=0 GundoShow call mundo#util#MundoShow()
 command! -nargs=0 GundoHide call mundo#util#MundoHide()
 command! -nargs=0 GundoRenderGraph call mundo#util#MundoRenderGraph()
+
 "}}}

--- a/plugin/mundo.vim
+++ b/plugin/mundo.vim
@@ -102,7 +102,6 @@ call mundo#util#set_default(
 command! -nargs=0 MundoToggle call mundo#MundoToggle()
 command! -nargs=0 MundoShow call mundo#MundoShow()
 command! -nargs=0 MundoHide call mundo#MundoHide()
-command! -nargs=0 MundoRenderGraph call mundo#MundoRenderGraph()
 command! -nargs=0 GundoToggle call mundo#util#MundoToggle()
 command! -nargs=0 GundoShow call mundo#util#MundoShow()
 command! -nargs=0 GundoHide call mundo#util#MundoHide()

--- a/tests/vim_test/plugin/gundo_test_utils.vim
+++ b/tests/vim_test/plugin/gundo_test_utils.vim
@@ -1,39 +1,46 @@
 let s:undolevels_save = &undolevels
 
 function! g:Goto(buffername)"{{{
-    exec bufwinnr(bufnr(a:buffername)) . 'wincmd w'
+    let l:winnr = bufwinnr(a:buffername)
+
+    if l:winnr == -1
+        return
+    endif
+
+    execute l:winnr . 'wincmd w'
 endfunction"}}}
 
 function! g:GotoLineContaining(text)"{{{
-    exe "silent! normal gg/\\M" . a:text . "\n"
+    let index = match(getline(1, '$'), '\V' . escape(a:text, '\'))
+
+    if index == -1
+        return
+    endif
+
+    call cursor(index + 1, 0)
 endfunction"}}}
 
 function! g:CurrentLineContains(text)"{{{
-    if stridx(getline('.'), a:text) != -1
-        return 1
-    else
-        return 0
-    endif
+    return stridx(getline('.'), a:text) != -1
 endfunction"}}}
 
 function! g:Contains(text)"{{{
-    call g:GotoLineContaining(a:text)
-    return g:CurrentLineContains(a:text)
+    return match(getline(1, '$'), '\V' . escape(a:text, '\')) != -1
 endfunction"}}}
 
 function! g:TypeLine(text)"{{{
-    exe "normal i" . a:text . "\<C-g>u\n\e"
+    execute "normal i" . a:text . "\<C-g>u\n\e"
 endfunction"}}}
 
 function! g:TypeLineDone(text)"{{{
-    exe "normal i" . a:text . "\n\e"
+    execute "normal i" . a:text . "\n\e"
 
     " Break the undo chain
     let &undolevels = s:undolevels_save
 endfunction"}}}
 
 function! g:PrintTheFuckingBuffer()"{{{
-    echo join(getline(1, 100000), "\n")
+    echo join(getline(1, '$'), "\n")
     echo "SOMETIMES I HATE YOU VIM"
 endfunction"}}}
 


### PR DESCRIPTION
This adds 2 new options:

* g:mundo_auto_preview_delay

When this option is set to a positive integer and auto preview is enabled, previews will only be rendered automatically after the cursor is stationary for g:mundo_auto_preview_delay milliseconds. Defaults to 0.

* g:mundo_inline_undo_delay

When this option is set, auto preview is enabled and g:mundo_auto_preview_delay is a positive integer, inline diffs will only be rendered after the cursor is stationary for g:mundo_auto_preview_delay milliseconds. Disabled by default.