### PR TITLE
Fix tests to be runnable

### DIFF
--- a/tests/vim_test/autoload/lh
+++ b/tests/vim_test/autoload/lh
@@ -1,1 +1,0 @@
-../../bundled/lh-vim-lib/autoload/lh

--- a/tests/vim_test/ftplugin/vim
+++ b/tests/vim_test/ftplugin/vim
@@ -1,1 +1,0 @@
-../../bundled/ut/ftplugin/vim

--- a/tests/vim_test/macros/menu-map.vim
+++ b/tests/vim_test/macros/menu-map.vim
@@ -1,1 +1,0 @@
-../../bundled/lh-vim-lib/macros/menu-map.vim

--- a/tests/vim_test/plugin/UT.vim
+++ b/tests/vim_test/plugin/UT.vim
@@ -1,1 +1,0 @@
-../../bundled/ut/plugin/UT.vim

--- a/tests/vim_test/plugin/gundo.vim
+++ b/tests/vim_test/plugin/gundo.vim
@@ -1,1 +1,0 @@
-../../../plugin/gundo.vim

--- a/tests/vim_test/plugin/let.vim
+++ b/tests/vim_test/plugin/let.vim
@@ -1,1 +1,0 @@
-../../bundled/lh-vim-lib/plugin/let.vim

--- a/tests/vim_test/plugin/lhvl.vim
+++ b/tests/vim_test/plugin/lhvl.vim
@@ -1,1 +1,0 @@
-../../bundled/lh-vim-lib/plugin/lhvl.vim

--- a/tests/vim_test/plugin/ui-functions.vim
+++ b/tests/vim_test/plugin/ui-functions.vim
@@ -1,1 +1,0 @@
-../../bundled/lh-vim-lib/plugin/ui-functions.vim

--- a/tests/vim_test/plugin/words_tools.vim
+++ b/tests/vim_test/plugin/words_tools.vim
@@ -1,1 +1,0 @@
-../../bundled/lh-vim-lib/plugin/words_tools.vim

--- a/tests/vimrc_test
+++ b/tests/vimrc_test
@@ -1,5 +1,10 @@
 set nocompatible
-set runtimepath=vim_test
+let mundo_root = simplify(expand("<sfile>:h:h"))
+let mundo_test_bundle = mundo_root .'/tests/bundled'
+let &runtimepath  =      mundo_root
+let &runtimepath .= ','. mundo_root .'/tests/vim_test'
+let &runtimepath .= ','. mundo_test_bundle .'/lh-vim-lib'
+let &runtimepath .= ','. mundo_test_bundle .'/ut'
 filetype plugin on
 nnoremap q :qa!<cr>
 color desert


### PR DESCRIPTION
In short: tests wouldn't execute and there were broken symlinks. Now tests run, but some fail.

One of the symlinks was still pointing to the old gundo file. Fixing
that wasn't enough. The tests were failing to even load due to some
problem with the symlinks (mundo's autoload functions were not defined
but mundo's commands were).

Remove all symlinks and add the paths in the test vimrc's runtimepath
instead.

Several tests fail (test-graph and test-preview). Not sure how long
they've been broken or if the breaks are valid.

(I found this because I was getting an error when grepping:

    ~/.vim/$ grep hsdfsf -R .
    grep: ./bundle/gundo/tests/vim_test/plugin/gundo.vim: No such file or directory

Deleting the symlink fixes that problem.)

I guess this means tests haven't been run in ages : )