### PR TITLE
Do not remap <up>/<down> when already mapped

### DIFF
--- a/autoload/mundo.vim
+++ b/autoload/mundo.vim
@@ -88,7 +88,7 @@ function! s:MundoMapGraph()"{{{
     exec 'nnoremap <script> <silent> <buffer> ' . g:mundo_map_move_newer . " :<C-u>call <sid>MundoPython('MundoMove(-1,'. v:count .')')<CR>"
     nnoremap <script> <silent> <buffer> <CR>          :call <sid>MundoPython('MundoRevert()')<CR>
     nnoremap <script> <silent> <buffer> o             :call <sid>MundoPython('MundoRevert()')<CR>
-    if empty(maparg('<down>', 'n')) && empty(maparg('<up>', 'n'))
+    if g:mundo_map_up_down
         nnoremap <script> <silent> <buffer> <down>        :<C-u>call <sid>MundoPython('MundoMove(1,'. v:count .')')<CR>
         nnoremap <script> <silent> <buffer> <up>          :<C-u>call <sid>MundoPython('MundoMove(-1,'. v:count .')')<CR>
     endif

--- a/autoload/mundo.vim
+++ b/autoload/mundo.vim
@@ -88,8 +88,10 @@ function! s:MundoMapGraph()"{{{
     exec 'nnoremap <script> <silent> <buffer> ' . g:mundo_map_move_newer . " :<C-u>call <sid>MundoPython('MundoMove(-1,'. v:count .')')<CR>"
     nnoremap <script> <silent> <buffer> <CR>          :call <sid>MundoPython('MundoRevert()')<CR>
     nnoremap <script> <silent> <buffer> o             :call <sid>MundoPython('MundoRevert()')<CR>
-    nnoremap <script> <silent> <buffer> <down>        :<C-u>call <sid>MundoPython('MundoMove(1,'. v:count .')')<CR>
-    nnoremap <script> <silent> <buffer> <up>          :<C-u>call <sid>MundoPython('MundoMove(-1,'. v:count .')')<CR>
+    if empty(maparg('<down>', 'n')) && empty(maparg('<up>', 'n'))
+        nnoremap <script> <silent> <buffer> <down>        :<C-u>call <sid>MundoPython('MundoMove(1,'. v:count .')')<CR>
+        nnoremap <script> <silent> <buffer> <up>          :<C-u>call <sid>MundoPython('MundoMove(-1,'. v:count .')')<CR>
+    endif
     nnoremap <script> <silent> <buffer> J             :<C-u>call <sid>MundoPython('MundoMove(1,'. v:count .',True,True)')<CR>
     nnoremap <script> <silent> <buffer> K             :<C-u>call <sid>MundoPython('MundoMove(-1,'. v:count .',True,True)')<CR>
     nnoremap <script> <silent> <buffer> gg            gg:<C-u>call <sid>MundoPython('MundoMove(1,'. v:count .')')<CR>

--- a/autoload/mundo/util.vim
+++ b/autoload/mundo/util.vim
@@ -62,6 +62,10 @@ call mundo#util#set_default(
             \ 'g:gundo_map_move_newer')
 
 call mundo#util#set_default(
+            \ 'g:mundo_map_up_down', 1,
+            \ 'g:gundo_map_up_down')
+
+call mundo#util#set_default(
             \ 'g:mundo_close_on_revert', 0,
             \ 'g:gundo_close_on_revert')
 

--- a/doc/mundo.txt
+++ b/doc/mundo.txt
@@ -25,6 +25,7 @@ CONTENTS                                                      *Mundo-contents*
         3.13 mundo_mirror_graph ........ |mundo_mirror_graph|
         3.14 mundo_inline_undo ......... |mundo_inline_undo|
         3.15 mundo_return_on_revert .... |mundo_return_on_revert|
+        3.16 mundo_map_up_down ......... |mundo_map_up_down|
     4. License ......................... |MundoLicense|
     5. Bugs ............................ |MundoBugs|
     6. Contributing .................... |MundoContributing|
@@ -260,6 +261,14 @@ Default: 0 (no inline graph)
 3.15 g:mundo_return_on_revert                         *mundo_return_on_revert*
 
 Set this to 0 to keep focus in the Mundo window after a revert.
+
+Default: 1
+
+------------------------------------------------------------------------------
+3.16 g:mundo_map_up_down                                   *mundo_map_up_down*
+
+By default, <Up> and <Down> are mapped to navigate up and down the undo graph.
+Set this to 0 to prevent these mappings.
 
 Default: 1
 


### PR DESCRIPTION
Check whether a mapping already exists for <up> or <down> before remapping. If either exists already, it indicates an alternate workflow for these keys (e.g. window resizing) that shouldn't automatically be overridden.