### PR TITLE
Adds a g;mundo_mappings option (#72)

### DIFF
--- a/autoload/mundo.py
+++ b/autoload/mundo.py
@@ -55,9 +55,10 @@ def _check_sanity():
 
     return True
 
+
 INLINE_HELP = '''\
 " Mundo (%d) - Press ? for Help:
-" %s/%s  - Next/Prev undo state.
+" j/k  - Next/Prev undo state.
 " J/K  - Next/Prev write state.
 " i    - Toggle 'inline diff' mode.
 " /    - Find changes that match string.
@@ -96,9 +97,7 @@ def MundoRenderGraph(force=False):# {{{
     last_visible_line = int(vim.eval("line('w$')"))
 
     verbose = vim.eval('g:mundo_verbose_graph') == "1"
-    target = (int(vim.eval('g:mundo_target_n')),
-                vim.eval('g:mundo_map_move_older'),
-                vim.eval('g:mundo_map_move_newer'))
+    target = int(vim.eval('g:mundo_target_n'))
 
     if int(vim.eval('g:mundo_help')):
         header = (INLINE_HELP % target).splitlines()

--- a/autoload/mundo/util.vim
+++ b/autoload/mundo/util.vim
@@ -59,6 +59,7 @@ endfunction"}}}
 function! mundo#util#set_default(var, val, ...)"{{{
     if !exists(a:var)
         let {a:var} = a:val
+        return 1
     endif
 
     let old_var = get(a:000, 0, '')
@@ -74,7 +75,10 @@ function! mundo#util#set_default(var, val, ...)"{{{
                     \ .'}'
         )
     endif
-endfunction"}}}
+
+    return 0
+endfunction
+"}}}
 
 "}}}
 

--- a/doc/mundo.txt
+++ b/doc/mundo.txt
@@ -14,8 +14,7 @@ CONTENTS                                                      *Mundo-contents*
         3.4  mundo_right ............... |mundo_right|
         3.5  mundo_help ................ |mundo_help|
         3.6  mundo_disable ............. |mundo_disable|
-        3.7  mundo_map_move_older ...... |mundo_map_move_older|
-             mundo_map_move_newer ...... |mundo_map_move_newer|
+        3.7  mundo_mappings ............ |mundo_mappings|
         3.8  mundo_close_on_revert ..... |mundo_close_on_revert|
         3.9  mundo_preview_statusline .. |mundo_preview_statusline|
              mundo_tree_statusline ..... |mundo_tree_statusline|
@@ -26,7 +25,6 @@ CONTENTS                                                      *Mundo-contents*
         3.14 mundo_mirror_graph ........ |mundo_mirror_graph|
         3.15 mundo_inline_undo ......... |mundo_inline_undo|
         3.16 mundo_return_on_revert .... |mundo_return_on_revert|
-        3.17 mundo_map_up_down ......... |mundo_map_up_down|
     4. License ......................... |MundoLicense|
     5. Bugs ............................ |MundoBugs|
     6. Contributing .................... |MundoContributing|
@@ -191,14 +189,42 @@ them may not have Python support.
 Default: 0 (Mundo is enabled as usual)
 
 ------------------------------------------------------------------------------
-3.7 g:mundo_map_move_older, g:mundo_map_move_newer      *mundo_map_move_older*
+3.7 g:mundo_mappings                                    *mundo_mappings*
+                                                        *mundo_map_move_older*
                                                         *mundo_map_move_newer*
+                                                        *mundo_map_up_down*
 
-These options let you change the keys that navigate the undo graph. This is
-useful if you use a Dvorak keyboard and have changed your movement keys.
+To override any mappings within mundo set the value of the normal mode keys you
+would like to use instead (copy the defaults below and adjust as preferred)
 
-Default: mundo_map_move_older = "j"
-         mundo_map_move_newer = "k"
+Note: mundo_map_move_older, mundo_map_move_newer, mundo_map_up_down options have
+been deprecated in favor of settings here.  Although they continue to work, they
+will eventually be removed!
+
+Defaults:
+
+let g:mundo_mappings = {
+          \ '<CR>': 'preview',
+          \ 'o': 'preview',
+          \ 'j': 'move_older',
+          \ 'k': 'move_newer',
+          \ '<up>': 'move_older',
+          \ '<down>': 'move_newer',
+          \ 'J': 'move_older_write',
+          \ 'K': 'move_newer_write',
+          \ 'gg': 'move_top',
+          \ 'G': 'move_bottom',
+          \ 'P': 'play_to',
+          \ 'd': 'diff',
+          \ 'i': 'toggle_inline',
+          \ '/': 'search',
+          \ 'n': 'next_match',
+          \ 'N': 'previous_match',
+          \ 'p': 'diff_current_buffer',
+          \ 'r': 'diff',
+          \ '?': 'toggle_help',
+          \ 'q': 'quit',
+          \ '<2-LeftMouse>': 'mouse_click' }
 
 ------------------------------------------------------------------------------
 3.8 g:mundo_close_on_revert                            *mundo_close_on_revert*
@@ -276,14 +302,6 @@ Set this to 0 to keep focus in the Mundo window after a revert.
 
 Default: 1
 
-------------------------------------------------------------------------------
-3.17 g:mundo_map_up_down                                   *mundo_map_up_down*
-
-By default, <Up> and <Down> are mapped to navigate up and down the undo graph.
-Set this to 0 to prevent these mappings.
-
-Default: 1
-
 ==============================================================================
 4. License                                                      *MundoLicense*
 
@@ -310,6 +328,9 @@ GitHub: https://github.com/simnalamburt/vim-mundo
 7. Changelog                                                  *MundoChangelog*
 
 
+v3.2.0
+    * Adds g:mundo_mappings setting.
+    * Deprecates g:mundo_map_move_older, g:mundo_map_move_newer, g:mundo_map_up_down
 v3.1.0
     * Adds g:mundo_map_up_down setting.
     * Adds g:mundo_auto_preview_delay setting.

--- a/plugin/mundo.vim
+++ b/plugin/mundo.vim
@@ -95,6 +95,34 @@ call mundo#util#set_default(
             \ 'g:mundo_width', 45,
             \ 'g:gundo_width')
 
+" Set up the default mappings, unless a g:mundo_mappings has already been
+" provided
+if mundo#util#set_default('g:mundo_mappings', {})
+    let g:mundo_mappings = {
+                \ '<CR>': 'preview',
+                \ 'o': 'preview',
+                \ 'J': 'move_older_write',
+                \ 'K': 'move_newer_write',
+                \ 'gg': 'move_top',
+                \ 'G': 'move_bottom',
+                \ 'P': 'play_to',
+                \ 'd': 'diff',
+                \ 'i': 'toggle_inline',
+                \ '/': 'search',
+                \ 'n': 'next_match',
+                \ 'N': 'previous_match',
+                \ 'p': 'diff_current_buffer',
+                \ 'r': 'diff',
+                \ '?': 'toggle_help',
+                \ 'q': 'quit',
+                \ '<2-LeftMouse>': 'mouse_click' }
+    let g:mundo_mappings[g:mundo_map_move_older] = 'move_older'
+    let g:mundo_mappings[g:mundo_map_move_newer] = 'move_newer'
+    if g:mundo_map_up_down
+        let g:mundo_mappings['<down>'] = 'move_newer'
+        let g:mundo_mappings['<up>'] = 'move_older'
+    endif
+endif
 "}}}
 
 "{{{ Create commands


### PR DESCRIPTION
This deprecates several options, in favor of adding the ability for users to remap in any way they wish.

This change makes it possible for a user to set up their own mappings, in any way they wish. To do so:

 * Copy the `g:mundo_mappings` settings in the help doc, add it to their .vimrc and customize.