### PR TITLE
Ignore `tags` in all `doc` subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/doc/tags
+**/doc/**/tags
 *.pyc


### PR DESCRIPTION
Without this change, after generating :helptags, we have the two
following tags that should be ignored:

    tests/bundled/lh-vim-lib/doc/tags
    tests/bundled/ut/doc/tags