### PR TITLE
Make `__Mundo__`, `__Mundo_Preview__` fired earlier

### DIFF
--- a/autoload/mundo.vim
+++ b/autoload/mundo.vim
@@ -546,8 +546,16 @@ augroup MundoAug
                     \ call s:MundoRenderPreview() |
                     \ call s:MundoStopRefreshTimer() |
                 \ endif |
-    autocmd BufEnter __Mundo__ call s:MundoSettingsGraph()
-    autocmd BufEnter __Mundo_Preview__ call s:MundoSettingsPreview()
+
+    " Re-applying syntax highlights and remapping keymaps at both BufNewFile and
+    " BufEnter. See references for the further details
+    "
+    " References:
+    "   https://github.com/simnalamburt/vim-mundo/pull/74
+    "   https://github.com/simnalamburt/vim-mundo/issues/92
+    autocmd BufNewFile,BufEnter __Mundo__ call s:MundoSettingsGraph()
+    autocmd BufNewFile,BufEnter __Mundo_Preview__ call s:MundoSettingsPreview()
+
     autocmd CursorHold,CursorMoved,TextChanged,InsertLeave *
                 \ call s:MundoRefresh()
 augroup END


### PR DESCRIPTION
**NOTE**: Discussion in https://github.com/simnalamburt/vim-mundo/issues/92 is not finished yet. This is a draft PR made early to make decision faster.

&nbsp;

We used `BufNewFile` to fire `__Mundo__` and `__Mundo_Preview__` in long time ago and changed it into `BufEnter` intensionally at #74. But someone (#92) wanted it to be executed little bit earlier. So I hereby made `__Mundo__`, `__Mundo_Preview__` be executed at both `BufNewFile` and `BufEnter`.

###### References:
- https://github.com/simnalamburt/vim-mundo/pull/74
- https://github.com/simnalamburt/vim-mundo/issues/92