### PR TITLE
do not try to show undotree of a preview window

### DIFF
--- a/autoload/mundo.vim
+++ b/autoload/mundo.vim
@@ -409,6 +409,9 @@ function! s:MundoPythonRestoreView(fn)"{{{
     let eventignoreBack = &eventignore
     set eventignore=BufLeave,BufEnter,CursorHold,CursorMoved,TextChanged
                 \,InsertLeave
+
+    " Don't show undotree of a preview window
+    " Reference: https://github.com/simnalamburt/vim-mundo/pull/102
     if has('popupwin')
         if type(currentWin) == type(0) && currentWin == 0
             return

--- a/autoload/mundo.vim
+++ b/autoload/mundo.vim
@@ -409,7 +409,11 @@ function! s:MundoPythonRestoreView(fn)"{{{
     let eventignoreBack = &eventignore
     set eventignore=BufLeave,BufEnter,CursorHold,CursorMoved,TextChanged
                 \,InsertLeave
-
+    if has('popupwin')
+        if type(currentWin) == type(0) && currentWin == 0
+            return
+        endif
+    endif
     " Call python function
     call s:MundoPython(a:fn)
 


### PR DESCRIPTION
if mundo tree is shown and I open a preview window (e.g. by fzf vim plugin), an error
occurs since vim-mundo tries to show the undo tree of the preview window.
This patch prevents vim-mund to show the undo tree of a preview window thus suppressing
the error message.

Closese https://github.com/simnalamburt/vim-mundo/issues/103