### PR TITLE
force the writing of preview buffer to make diffpatch work

### DIFF
--- a/autoload/mundo.py
+++ b/autoload/mundo.py
@@ -381,7 +381,8 @@ def MundoRenderPatchdiff():# {{{
         # save the __Mundo_Preview__ buffer to a temp file.
         util._goto_window_for_buffer('__Mundo_Preview__')
         (handle,filename) = tempfile.mkstemp()
-        vim.command('silent! w %s' % (filename))
+        # use w! instead of w to force the writing of file 'filename'
+        vim.command('silent! w! %s' % (filename))
         # exit the __Mundo_Preview__ window
         vim.command('bdelete')
         # diff the temp file

--- a/autoload/mundo.vim
+++ b/autoload/mundo.vim
@@ -119,7 +119,7 @@ function! s:MundoMapGraph()"{{{
             call s:MundoMakeMapping(key, ":<C-u>call <sid>MundoPython('MundoPrevMatch()')<CR>")
         elseif l:value == "diff_current_buffer"
             call s:MundoMakeMapping(key, ":<C-u>call <sid>MundoPythonRestoreView('MundoRenderChangePreview()')<CR>")
-        elseif l:value == "diff"
+        elseif l:value == "rdiff"
             call s:MundoMakeMapping(key, ":<C-u>call <sid>MundoRenderPreview(1)<CR>")
         elseif l:value == "toggle_help"
             call s:MundoMakeMapping(key, ":<C-u>call <sid>MundoPython('MundoToggleHelp()')<CR>")

--- a/plugin/mundo.vim
+++ b/plugin/mundo.vim
@@ -114,7 +114,7 @@ if mundo#util#set_default('g:mundo_mappings', {})
                 \ 'n': 'next_match',
                 \ 'N': 'previous_match',
                 \ 'p': 'diff_current_buffer',
-                \ 'r': 'diff',
+                \ 'r': 'rdiff',
                 \ '?': 'toggle_help',
                 \ 'q': 'quit',
                 \ '<2-LeftMouse>': 'mouse_click' }


### PR DESCRIPTION
this PR fixes issues #97 and #105, i.e.
- without issuing 'w!' if the temporary file exists, the writing failed and diffpatch does not work
- use 'rdiff' instead of 'diff' in undo mapping related to key 'r' and change accordingly
   'diff' to 'rdiff' in ```function s:MundoMapGraph()``` in the file ```autoload/mundo.vim``` 