### PR TITLE
Display time stamps in ISO time format (fix regression)

### DIFF
--- a/autoload/mundo/node.py
+++ b/autoload/mundo/node.py
@@ -110,7 +110,7 @@ class Nodes(object):
         return current
 
     def _fmt_time(self,t):
-        return time.strftime('%Y-%m-%d %I:%M:%S %p', time.localtime(float(t)))
+        return time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(float(t)))
 
     def _get_lines(self,node):
         n = 0


### PR DESCRIPTION
Turns out the feature the [plugin stated](https://github.com/simnalamburt/vim-mundo#how-is-this-different-than-other-plugins) to have got broken a few years ago :)

Fixes: #3
Closes: https://github.com/sjl/gundo.vim/pull/28

Regression: 3b94d2d26306f2945e51ad77a9b5d94b0882f5bf
Introduced in: 32142a6ae0ae15d3abd745c404b7fb11c7d94df3