### PR TITLE
Perform `rstrip()` only newlines in util.py

### DIFF
--- a/autoload/mundo/util.py
+++ b/autoload/mundo/util.py
@@ -38,7 +38,7 @@ def _output_preview_text(lines):
     """ Output a list of lines to the mundo preview window. """
     _goto_window_for_buffer('__Mundo_Preview__')
     vim().command('setlocal modifiable')
-    vim().current.buffer[:] = [line.rstrip() for line in lines]
+    vim().current.buffer[:] = [line.rstrip('\n') for line in lines]
     vim().command('setlocal nomodifiable')
 
 


### PR DESCRIPTION
Currently trailing spaces are accidentally stripped in preview.

###### Reference
- https://github.com/simnalamburt/vim-mundo/commit/4e3b683dd809d41d8507872eb03cf110cd250af3