### PR TITLE
Use absolute imports

### DIFF
--- a/autoload/mundo/graphlog.py
+++ b/autoload/mundo/graphlog.py
@@ -1,5 +1,5 @@
 import time
-import util
+import mundo.util as util
 
 
 # Mercurial's graphlog code -------------------------------------------------------

--- a/autoload/mundo/node.py
+++ b/autoload/mundo/node.py
@@ -1,8 +1,8 @@
-import diff
+import mundo.diff as diff
 import difflib
 import itertools
 import time
-import util
+import mundo.util as util
 
 # Python undo tree data structures and functions ----------------------------------
 class Node(object):


### PR DESCRIPTION
Don't use relative imports since users may already have modules with
these names (they're pretty generic).

I hit a slew of errors when editing a project with util.py, but I'm not
entirely sure how to reproduce it. (`:edit util.py | write | MundoToggle`
only failed for me once.)

We're already using absolute imports in mundo.py, so this makes us consistent:

https://github.com/simnalamburt/vim-mundo/blob/c6dcea90166750bb5ed40321749966b1a8020a1a/autoload/mundo.py#L16-L18