### PR TITLE
Make help text fit in the default width

### DIFF
--- a/autoload/mundo.py
+++ b/autoload/mundo.py
@@ -58,17 +58,17 @@ def _check_sanity():
 
 INLINE_HELP = '''\
 " Mundo (%d) - Press ? for Help:
-" j/k  - Next/Prev undo state.
-" J/K  - Next/Prev write state.
-" i    - Toggle 'inline diff' mode.
-" /    - Find changes that match string.
-" n/N  - Next/Prev undo that matches search.
-" P    - Play current state to selected undo.
-" d    - Vert diff of undo with current state.
-" p    - Diff of selected undo and current state.
-" r    - Diff of selected undo and prior undo.
-" q    - Quit!
-" <cr> - Revert to selected state.
+" j/k   Next/Prev undo state.
+" J/K   Next/Prev write state.
+" i     Toggle 'inline diff' mode.
+" /     Find changes that match string.
+" n/N   Next/Prev undo that matches search.
+" P     Play current state to selected undo.
+" d     Vert diff of undo with current state.
+" p     Diff selected undo and current state.
+" r     Diff selected undo and prior undo.
+" q     Quit!
+" <cr>  Revert to selected state.
 
 '''
 


### PR DESCRIPTION
With the default width of 45 the help text doesn't quite fit. This
changes it so that it fits.

I tried to come up with a phrasing that was shorter so I didn't have the
remove the '-' characters, but I couldn't come up with anything. IMHO
it's also clear without them.

Here's how it looked before btw:

![xscreen-2021-07-13T16:06:26](https://user-images.githubusercontent.com/1032692/125416386-5bc35cb1-032f-44a0-80fa-c2ffb01e74a3.png)