### PR TITLE
Ignore WinLeave and WinEnter in s:MundoPythonResoreView()

### DIFF
--- a/autoload/mundo.vim
+++ b/autoload/mundo.vim
@@ -408,7 +408,7 @@ function! s:MundoPythonRestoreView(fn) "{{{
     let winView = winsaveview()
     let eventignoreBack = &eventignore
     set eventignore=BufLeave,BufEnter,CursorHold,CursorMoved,TextChanged
-                \,InsertLeave
+                \,InsertLeave,WinLeave,WinEnter
 
     " Don't show undotree of a preview window
     " Reference: https://github.com/simnalamburt/vim-mundo/pull/102


### PR DESCRIPTION
This fixes too frequent cursor splashing when plugin [Beacon](https://github.com/DanilaMihailov/beacon.nvim) is enabled.

Recently I installed the Beacon plugin which flashes cursor position on `WinEnter`. Now when the Mundo window is open, the flashes happen 3 times after switching windows (2 fast and 1 after a second). Here is an animation to show what happens:

![Peek 2022-06-09 11-15](https://user-images.githubusercontent.com/1219667/172802737-c0105524-4583-41ee-b2c9-1d2c1d20d095.gif)

The cursor also flashes when I move it inside the window. The reason is that Mundo moves between windows frequently without `WinEnter` masked.

In this PR I added `WinLeave` and `WinEnter` to the `eventignore` list in function `s:MundoPythonResoreView()`. This change fixes wrong cursor flashes while don't break Mundo functionality. Btw, the docs to the function says that only `BufNewFile` shouldn't be ignored:

```vim
" Wrapper for MundoPython() that restores the window state and prevents other
" Mundo autocommands (with the exception of BufNewFile) from triggering.
```