### PR TITLE
Issue 14 optimize preview

### DIFF
--- a/autoload/mundo.py
+++ b/autoload/mundo.py
@@ -387,7 +387,7 @@ def MundoRenderPatchdiff():# {{{
         vim.command('bdelete')
         # diff the temp file
         vim.command('silent! keepalt vert diffpatch %s' % (filename))
-        vim.command('set buftype=nofile bufhidden=delete')
+        vim.command('setlocal buftype=nofile bufhidden=delete')
         return True
     return False
 # }}}

--- a/autoload/mundo.vim
+++ b/autoload/mundo.vim
@@ -145,6 +145,7 @@ function! s:MundoSettingsGraph() "{{{
     setlocal bufhidden=hide
     setlocal noswapfile
     setlocal nobuflisted
+    setlocal nofoldenable
     setlocal nomodifiable
     setlocal filetype=Mundo
     setlocal nolist

--- a/autoload/mundo/graphlog.py
+++ b/autoload/mundo/graphlog.py
@@ -202,8 +202,10 @@ def generate(verbose, num_header_lines, first_visible_line, last_visible_line, i
             char = 'w'
         else:
             char = 'o'
-        show_inine_diff = inline_graph and line_number >= first_visible_line and line_number <= last_visible_line
-        preview_diff = nodesData.preview_diff(node.parent, node, False, show_inine_diff)
+        compute_preview = line_number >= first_visible_line and line_number <= last_visible_line
+        preview_diff = '...'
+        if compute_preview:
+            preview_diff = nodesData.preview_diff(node.parent, node, False, inline_graph)
         line = '[%s] %-10s %s' % (node.n, age_label, preview_diff)
         new_lines = ascii(state, 'C', char, [line], asciiedges(seen, node, parents), verbose)
         line_number += len(new_lines)


### PR DESCRIPTION
This PR adds the optimizations suggested by @resolritter

Also fixes small bug I noticed in big undos (the 'manual' diff folding might mark some undo messages as folded...we should disable folding altogether in the undotree).