### PR TITLE
Add <nowait> to mundo mappings

### DIFF
--- a/autoload/mundo.vim
+++ b/autoload/mundo.vim
@@ -85,7 +85,7 @@ endfunction "}}}
 "{{{ Mundo buffer settings
 
 function! s:MundoMakeMapping(mapping, action)
-    exec 'nnoremap <script> <silent> <buffer> ' . a:mapping .' '. a:action
+    exec 'nnoremap <script> <silent> <buffer> <nowait> ' . a:mapping .' '. a:action
 endfunction
 
 function! s:MundoMapGraph() "{{{


### PR DESCRIPTION
If a user sets 'notimeout' and also has mappings that start with any keys
that mundo maps to, they will need to press <esc> after the mundo-mapped
key to trigger the mundo mapping.

For example, if a user has vim-surround, `ds` is mapped to delete a
surround pair. If they want to trigger the default diff mundo mapping,
they will need to press `d<esc>` if they set 'notimeout', because vim
will wait to see if the user will press `s` after `d`.

Setting <nowait> in the mundo-mappings prevents this issue. This will
make any mappings that start with a key that mundo maps to unusable in
mundo windows, which should be harmless.